### PR TITLE
Minor (but important) taylorinteg bug fix

### DIFF
--- a/src/integration_methods.jl
+++ b/src/integration_methods.jl
@@ -281,7 +281,7 @@ function taylorinteg{T<:Number}(f, q0::Array{T,1}, t0::T, t_max::T,
     # Integration
     nsteps = 1
     while t0 < t_max
-        xold = x0
+        xold = copy(x0)
         δt = taylorstep!(f, t0, x0, order, abs_tol)
         if t0+δt ≥ t_max
             x0 = xold

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -142,4 +142,44 @@ facts("Tests: dot{x}=x.^2, x(0) = [3.0,1.0]") do
     @fact abs(xv[2,1] - 4.8) ≤ eps(4.8) --> true
 end
 
+facts("Test non-autonomous ODE: dot{x}=cos(t)") do
+    f(t, x) = [one(x[1]), cos(x[1])]
+    t0 = 0.0
+    tmax = 10.25*(2pi)
+    abstol = 1e-20
+    order = 25
+    x0 = [t0, 0.0] #initial conditions such that x(t)=sin(t)
+    tT, xT = taylorinteg(f, x0, t0, tmax, order, abstol)
+    @fact length(tT) < 501 --> true
+    @fact length(xT[:,1]) < 501 --> true
+    @fact length(xT[:,2]) < 501 --> true
+    if VERSION < v"0.5-"
+        @fact xT[1,1:end] --> x0'
+    else
+        @fact xT[1,1:end] --> x0
+    end
+    @fact tT[1] == t0 --> true
+    @fact xT[1,1] == x0[1] --> true
+    @fact xT[1,2] == x0[2] --> true
+    @fact tT[end] == xT[end,1] --> true
+    @fact abs(sin(tmax)-xT[end,2]) < 1e-14 --> true
+
+    tmax = 15*(2pi)
+    tT, xT = taylorinteg(f, x0, t0, tmax, order, abstol)
+    @fact length(tT) < 501 --> true
+    @fact length(xT[:,1]) < 501 --> true
+    @fact length(xT[:,2]) < 501 --> true
+    if VERSION < v"0.5-"
+        @fact xT[1,1:end] --> x0'
+    else
+        @fact xT[1,1:end] --> x0
+    end
+    @fact tT[1] == t0 --> true
+    @fact xT[1,1] == x0[1] --> true
+    @fact xT[1,2] == x0[2] --> true
+    @fact tT[end] == xT[end,1] --> true
+    @fact abs(sin(tmax)-xT[end,2]) < 1e-14 --> true
+
+end
+
 exitstatus()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,7 +34,8 @@ facts("Tests: dot{x}=x^2, x(0) = 1") do
 end
 
 facts("Tests: dot{x}=x^2, x(0) = 3; nsteps <= maxsteps") do
-    eqs_mov(t, x) = x.^2
+    eqs_mov(t, x) = x.^2 #the ODE (i.e., the equations of motion)
+    exactsol(t, x0) = x0/(1.0-x0*t) #the analytical solution
     t0 = 0.0
     tmax = 0.3
     x0 = 3.0
@@ -53,6 +54,7 @@ facts("Tests: dot{x}=x^2, x(0) = 3; nsteps <= maxsteps") do
     @fact xv[1] --> x0
     @fact tv[end] < 1/3 --> true
     @fact tv[end] --> tmax
+    @fact abs(xv[end]-exactsol(tv[end], xv[1])) < 2e-14 --> true
 
     tv, xv = taylorinteg(eqs_mov, q0, 0.0, tmax, _order, _abs_tol)
     @fact length(tv) < 501 --> true
@@ -68,6 +70,9 @@ facts("Tests: dot{x}=x^2, x(0) = 3; nsteps <= maxsteps") do
     end
     @fact tv[end] < 1/3 --> true
     @fact tv[end] --> tmax
+    @fact xv[end,1] --> xv[end,2]
+    @fact abs(xv[end,1]-exactsol(tv[end], xv[1,1])) < 2e-14 --> true
+    @fact abs(xv[end,2]-exactsol(tv[end], xv[1,2])) < 2e-14 --> true
 
     tmax = 0.33
 
@@ -79,6 +84,7 @@ facts("Tests: dot{x}=x^2, x(0) = 3; nsteps <= maxsteps") do
     @fact xv[1] --> x0
     @fact tv[end] < 1/3 --> true
     @fact tv[end] --> tmax
+    @fact abs(xv[end]-exactsol(tv[end], xv[1])) < 5e-12 --> true
 
     tv, xv = taylorinteg(eqs_mov, q0, 0.0, tmax, _order, _abs_tol)
     @fact length(tv) < 501 --> true
@@ -94,6 +100,9 @@ facts("Tests: dot{x}=x^2, x(0) = 3; nsteps <= maxsteps") do
     end
     @fact tv[end] < 1/3 --> true
     @fact tv[end] --> tmax
+    @fact xv[end,1] --> xv[end,2]
+    @fact abs(xv[end,1]-exactsol(tv[end], xv[1,1])) < 5e-12 --> true
+    @fact abs(xv[end,2]-exactsol(tv[end], xv[1,2])) < 5e-12 --> true
 end
 
 facts("Tests: dot{x}=x.^2, x(0) = [3.0,1.0]") do


### PR DESCRIPTION
This PR fixes a bug which prevented the correct evaluation of last step of `taylorinteg{T<:Number}(f, q0::Array{T,1}, t0::T, t_max::T, order::Int, abs_tol::T; [maxsteps])`