### PR TITLE
Fix required TaylorSeries version

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
 julia 0.5
-TaylorSeries 0.4.0
+TaylorSeries 0.5.0
 FactCheck 0.4.2


### PR DESCRIPTION
Forgot to change the REQUIRE file from TaylorSeries v0.4.0 to v0.5.0 when tagging TaylorIntegration v0.1.0... This PR fixes this error.