### PR TITLE
Add Taylor1{Taylor1{T}} integration methods; improve testing coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,1 @@
+comment: false

--- a/src/jettransport.jl
+++ b/src/jettransport.jl
@@ -1,6 +1,53 @@
 # This file is part of the TaylorIntegration.jl package; MIT licensed
 
 # jetcoeffs!
+function jetcoeffs!{T<:Number}(eqsdiff, t0::T, x::Taylor1{Taylor1{T}},
+        vT::Vector{T})
+    order = x.order
+    vT[1] = t0
+    for ord in 1:order
+        ordnext = ord+1
+
+        # Set `xaux`, auxiliary Taylor1 variable to order `ord`
+        @inbounds xaux = Taylor1( x.coeffs[1:ord] )
+
+        # Equations of motion
+        # TODO! define a macro to optimize the eqsdiff
+        tT = Taylor1(vT[1:ord])
+        dx = eqsdiff(tT, xaux)
+
+        # Recursion relation
+        @inbounds x[ordnext] = dx[ord]/ord
+    end
+    nothing
+end
+
+function jetcoeffs!{T<:Number}(eqsdiff!, t0::T, x::Vector{Taylor1{Taylor1{T}}},
+        dx::Vector{Taylor1{Taylor1{T}}}, xaux::Vector{Taylor1{Taylor1{T}}},
+        vT::Vector{T})
+    order = x[1].order
+    vT[1] = t0
+    for ord in 1:order
+        ordnext = ord+1
+
+        # Set `xaux`, auxiliary vector of Taylor1 to order `ord`
+        for j in eachindex(x)
+            @inbounds xaux[j] = Taylor1( x[j].coeffs[1:ord] )
+        end
+
+        # Equations of motion
+        # TODO! define a macro to optimize the eqsdiff
+        tT = Taylor1(vT[1:ord])
+        eqsdiff!(tT, xaux, dx)
+
+        # Recursion relations
+        for j in eachindex(x)
+            @inbounds x[j][ordnext] = dx[j][ord]/ord
+        end
+    end
+    nothing
+end
+
 function jetcoeffs!{T<:Number}(eqsdiff, t0::T, x::Taylor1{TaylorN{T}},
         vT::Vector{T})
     order = x.order
@@ -49,6 +96,32 @@ function jetcoeffs!{T<:Number}(eqsdiff!, t0::T, x::Vector{Taylor1{TaylorN{T}}},
 end
 
 # stepsize
+function stepsize{T<:Number}(x::Taylor1{Taylor1{T}}, epsilon::T)
+    ord = x.order
+    h = convert(T, Inf)
+    for k in (ord-1, ord)
+        @inbounds aux = Array{T}(x[k+1].order)
+        for i in 1:x[k+1].order
+            @inbounds aux[i] = norm(x[k+1][i],Inf)
+        end
+        aux == zeros(T, length(aux)) && continue
+        aux = epsilon ./ aux
+        kinv = one(T)/k
+        aux = aux.^kinv
+        h = min(h, minimum(aux))
+    end
+    return h
+end
+
+function stepsize{T<:Number}(q::Array{Taylor1{Taylor1{T}},1}, epsilon::T)
+    h = convert(T, Inf)
+    for i in eachindex(q)
+        @inbounds hi = stepsize( q[i], epsilon )
+        h = min( h, hi )
+    end
+    return h
+end
+
 function stepsize{T<:Number}(x::Taylor1{TaylorN{T}}, epsilon::T)
     ord = x.order
     h = convert(T, Inf)
@@ -76,6 +149,32 @@ function stepsize{T<:Number}(q::Array{Taylor1{TaylorN{T}},1}, epsilon::T)
 end
 
 # taylorstep!
+function taylorstep!{T<:Number}(f, x::Taylor1{Taylor1{T}}, t0::T, t1::T,
+        x0::Taylor1{T}, order::Int, abstol::T, vT::Vector{T})
+    @assert t1 > t0
+    # Compute the Taylor coefficients
+    jetcoeffs!(f, t0, x, vT)
+    # Compute the step-size of the integration using `abstol`
+    δt = stepsize(x, abstol)
+    δt = min(δt, t1-t0)
+    x0 = evaluate(x, δt)
+    return δt, x0
+end
+
+function taylorstep!{T<:Number}(f, x::Vector{Taylor1{Taylor1{T}}},
+        dx::Vector{Taylor1{Taylor1{T}}}, xaux::Vector{Taylor1{Taylor1{T}}},
+        t0::T, t1::T, x0::Array{Taylor1{T},1}, order::Int, abstol::T,
+        vT::Vector{T})
+    @assert t1 > t0
+    # Compute the Taylor coefficients
+    jetcoeffs!(f, t0, x, dx, xaux, vT)
+    # Compute the step-size of the integration using `abstol`
+    δt = stepsize(x, abstol)
+    δt = min(δt, t1-t0)
+    evaluate!(x, δt, x0)
+    return δt
+end
+
 function taylorstep!{T<:Number}(f, x::Taylor1{TaylorN{T}}, t0::T, t1::T,
         x0::TaylorN{T}, order::Int, abstol::T, vT::Vector{T})
     @assert t1 > t0
@@ -103,6 +202,184 @@ function taylorstep!{T<:Number}(f, x::Vector{Taylor1{TaylorN{T}}},
 end
 
 # taylorinteg
+function taylorinteg{T<:Number}(f, x0::Taylor1{T}, t0::T, tmax::T, order::Int,
+        abstol::T; maxsteps::Int=500)
+
+    # Allocation
+    const tv = Array{T}(maxsteps+1)
+    const xv = Array{Taylor1{T}}(maxsteps+1)
+    const vT = zeros(T, order+1)
+    vT[2] = one(T)
+
+    # Initialize the Taylor1 expansions
+    x = Taylor1( x0, order )
+
+    # Initial conditions
+    nsteps = 1
+    @inbounds tv[1] = t0
+    @inbounds xv[1] = x0
+
+    # Integration
+    while t0 < tmax
+        δt, x0 = taylorstep!(f, x, t0, tmax, x0, order, abstol, vT)
+        x[1] = x0
+        t0 += δt
+        nsteps += 1
+        @inbounds tv[nsteps] = t0
+        @inbounds xv[nsteps] = x0
+        if nsteps > maxsteps
+            warn("""
+            Maximum number of integration steps reached; exiting.
+            """)
+            break
+        end
+    end
+
+    #return tv, xv
+    return view(tv,1:nsteps), view(xv,1:nsteps)
+end
+
+function taylorinteg{T<:Number}(f, q0::Array{Taylor1{T},1}, t0::T, tmax::T,
+        order::Int, abstol::T; maxsteps::Int=500)
+
+    # Allocation
+    const tv = Array{T}(maxsteps+1)
+    dof = length(q0)
+    const xv = Array{Taylor1{T}}(dof, maxsteps+1)
+    const vT = zeros(T, order+1)
+    vT[2] = one(T)
+
+    # Initialize the vector of Taylor1 expansions
+    const x = Array{Taylor1{Taylor1{T}}}(dof)
+    const dx = Array{Taylor1{Taylor1{T}}}(dof)
+    const xaux = Array{Taylor1{Taylor1{T}}}(dof)
+    for i in eachindex(q0)
+        @inbounds x[i] = Taylor1( q0[i], order )
+    end
+
+    # Initial conditions
+    @inbounds tv[1] = t0
+    @inbounds xv[:,1] .= q0
+    x0 = copy(q0)
+
+    # Integration
+    nsteps = 1
+    while t0 < tmax
+        δt = taylorstep!(f, x, dx, xaux, t0, tmax, x0, order, abstol, vT)
+        for i in eachindex(x0)
+            @inbounds x[i][1] = x0[i]
+        end
+        t0 += δt
+        nsteps += 1
+        @inbounds tv[nsteps] = t0
+        @inbounds xv[:,nsteps] .= x0
+        if nsteps > maxsteps
+            warn("""
+            Maximum number of integration steps reached; exiting.
+            """)
+            break
+        end
+    end
+
+    # return view(tv,1:nsteps), view(transpose(xv),1:nsteps,:)
+    return view(tv,1:nsteps), transpose(view(xv,:,1:nsteps))
+end
+
+function taylorinteg{T<:Number}(f, x0::Taylor1{T}, trange::Range{T},
+        order::Int, abstol::T; maxsteps::Int=500)
+
+    # Allocation
+    nn = length(trange)
+    const xv = Array{Taylor1{T}}(nn)
+    fill!(xv, Taylor1{T}(NaN))
+    const vT = zeros(T, order+1)
+    vT[2] = one(T)
+
+    # Initialize the Taylor1 expansions
+    x = Taylor1( x0, order )
+
+    # Initial conditions
+    @inbounds xv[1] = x0
+
+    # Integration
+    iter = 1
+    while iter < nn
+        t0, t1 = trange[iter], trange[iter+1]
+        nsteps = 0
+        while nsteps < maxsteps
+            δt, x0 = taylorstep!(f, x, t0, t1, x0, order, abstol, vT)
+            @inbounds x[1] = x0
+            t0 += δt
+            t0 ≥ t1 && break
+            nsteps += 1
+        end
+        if nsteps ≥ maxsteps && t0 != t1
+            warn("""
+            Maximum number of integration steps reached; exiting.
+            """)
+            break
+        end
+        iter += 1
+        @inbounds xv[iter] = x0
+    end
+
+    return xv
+end
+
+function taylorinteg{T<:Number}(f, q0::Array{Taylor1{T},1}, trange::Range{T},
+        order::Int, abstol::T; maxsteps::Int=500)
+
+    # Allocation
+    nn = length(trange)
+    dof = length(q0)
+    const x0 = similar(q0, Taylor1{T}, dof)
+    fill!(x0, Taylor1{T}(NaN))
+    const xv = Array{eltype(q0)}(dof, nn)
+    for ind in 1:nn
+        @inbounds xv[:,ind] .= x0
+    end
+    const vT = zeros(T, order+1)
+    vT[2] = one(T)
+
+    # Initialize the vector of Taylor1 expansions
+    const x = Array{Taylor1{Taylor1{T}}}(dof)
+    const dx = Array{Taylor1{Taylor1{T}}}(dof)
+    const xaux = Array{Taylor1{Taylor1{T}}}(dof)
+    for i in eachindex(q0)
+        @inbounds x[i] = Taylor1( q0[i], order )
+    end
+
+    # Initial conditions
+    @inbounds x0 .= q0
+    @inbounds xv[:,1] .= q0
+
+    # Integration
+    iter = 1
+    while iter < nn
+        t0, t1 = trange[iter], trange[iter+1]
+        nsteps = 0
+        while nsteps < maxsteps
+            δt = taylorstep!(f, x, dx, xaux, t0, t1, x0, order, abstol, vT)
+            for i in eachindex(x0)
+                @inbounds x[i][1] = x0[i]
+            end
+            t0 += δt
+            t0 ≥ t1 && break
+            nsteps += 1
+        end
+        if nsteps ≥ maxsteps && t0 != t1
+            warn("""
+            Maximum number of integration steps reached; exiting.
+            """)
+            break
+        end
+        iter += 1
+        @inbounds xv[:,iter] .= x0
+    end
+
+    return transpose(xv)
+end
+
 function taylorinteg{T<:Number}(f, x0::TaylorN{T}, t0::T, tmax::T, order::Int,
         abstol::T; maxsteps::Int=500)
 

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -25,6 +25,9 @@ end
     @test isapprox( zsol1[2]  , z0*exp(-tr[2]) )
     @test isapprox( zsol1[6], z0*exp(-tr[6]) )
     @test isapprox( zsol1[end], z0*exp(-tr[end]) )
+    tt, zsol1 = taylorinteg(eqs1, z0, 0.0, 2pi, 28, 1.0e-20, maxsteps=1)
+    @test length(tt) == 2
+    @test length(zsol1) == 2
     tt, zsol1 = taylorinteg(eqs1, z0, 0.0, 2pi, 28, 1.0e-20)
     @test zsol1[1] == z0
     @test isapprox( zsol1[2]  , z0*exp(-tt[2]) )
@@ -41,6 +44,9 @@ end
     @test zsol2[1] == z0
     @test isapprox( zsol2[3], z0*exp( complex(0.0, tr[3])) )
     @test isapprox( zsol2[5], z0*exp( complex(0.0, tr[5])) )
+    tt, zsol2 = taylorinteg(eqs2, z0, 0.0, 2pi, 28, 1.0e-20, maxsteps=1)
+    @test length(tt) == 2
+    @test length(zsol2) == 2
     tt, zsol2 = taylorinteg(eqs2, z0, 0.0, 2pi, 28, 1.0e-20)
     @test zsol2[1] == z0
     @test isapprox( zsol2[2], z0*exp( complex(0.0, tt[2])) )
@@ -59,6 +65,9 @@ end
     @test isapprox( zsol3[7,1], z0*exp(-tr[7]) )
     @test isapprox( zsol3[4,2], z0*exp( complex(0.0, tr[4])) )
     @test isapprox( zsol3[7,2], z0*exp( complex(0.0, tr[7])) )
+    tt, zsol3 = taylorinteg(eqs3!, zz0, 0.0, 2pi, 28, 1.0e-20, maxsteps=1)
+    @test length(tt) == 2
+    @test size(zsol3) == (length(tt), length(zz0))
     tt, zsol3 = taylorinteg(eqs3!, zz0, 0.0, 2pi, 28, 1.0e-20)
     @test zsol3[1,1] == z0
     @test zsol3[1,2] == z0

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -18,6 +18,8 @@ end
     z0 = complex(0.0, 1.0)
     tr = 0.0:pi/8:2pi
 
+    zsol1 = taylorinteg(eqs1, z0, tr, 28, 1.0e-20, maxsteps=1)
+    @test length(zsol1) == length(tr)
     zsol1 = taylorinteg(eqs1, z0, tr, 28, 1.0e-20)
     @test zsol1[1] == z0
     @test isapprox( zsol1[2]  , z0*exp(-tr[2]) )
@@ -33,6 +35,8 @@ end
     z0 = complex(0.0, 1.0)
     tr = 0.0:pi/8:2pi
 
+    zsol2 = taylorinteg(eqs2, z0, tr, 28, 1.0e-20, maxsteps=1)
+    @test length(zsol2) == length(tr)
     zsol2 = taylorinteg(eqs2, z0, tr, 28, 1.0e-20)
     @test zsol2[1] == z0
     @test isapprox( zsol2[3], z0*exp( complex(0.0, tr[3])) )
@@ -45,14 +49,17 @@ end
 
 @testset "Test integration of ODE with complex dependent variables (3)" begin
     z0 = complex(0.0, 1.0)
+    zz0 = [z0, z0]
     tr = 0.0:pi/8:2pi
 
+    zsol3 = taylorinteg(eqs3!, zz0, tr, 28, 1.0e-20, maxsteps=1)
+    @test size(zsol3) == (length(tr), length(zz0))
     zsol3 = taylorinteg(eqs3!, [z0, z0], tr, 28, 1.0e-20)
     @test isapprox( zsol3[4,1], z0*exp(-tr[4]) )
     @test isapprox( zsol3[7,1], z0*exp(-tr[7]) )
     @test isapprox( zsol3[4,2], z0*exp( complex(0.0, tr[4])) )
     @test isapprox( zsol3[7,2], z0*exp( complex(0.0, tr[7])) )
-    tt, zsol3 = taylorinteg(eqs3!, [z0,z0], 0.0, 2pi, 28, 1.0e-20)
+    tt, zsol3 = taylorinteg(eqs3!, zz0, 0.0, 2pi, 28, 1.0e-20)
     @test zsol3[1,1] == z0
     @test zsol3[1,2] == z0
     @test isapprox( zsol3[2,1], z0*exp( -tt[2]) )

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -17,18 +17,21 @@ end
 @testset "Test integration of ODE with complex dependent variables (1)" begin
     z0 = complex(0.0, 1.0)
     tr = 0.0:pi/8:2pi
-
-    zsol1 = taylorinteg(eqs1, z0, tr, 28, 1.0e-20, maxsteps=1)
+    ts = 0.0:pi:2pi
+    zsol1 = taylorinteg(eqs1, z0, ts, _order, _abstol, maxsteps=1)
+    # @test length(zsol1) == length(tr)
+    @test size(zsol1) == (length(ts),)
+    zsol1 = taylorinteg(eqs1, z0, tr, _order, _abstol, maxsteps=1)
     @test length(zsol1) == length(tr)
-    zsol1 = taylorinteg(eqs1, z0, tr, 28, 1.0e-20)
+    zsol1 = taylorinteg(eqs1, z0, tr, _order, _abstol)
     @test zsol1[1] == z0
     @test isapprox( zsol1[2]  , z0*exp(-tr[2]) )
     @test isapprox( zsol1[6], z0*exp(-tr[6]) )
     @test isapprox( zsol1[end], z0*exp(-tr[end]) )
-    tt, zsol1 = taylorinteg(eqs1, z0, 0.0, 2pi, 28, 1.0e-20, maxsteps=1)
+    tt, zsol1 = taylorinteg(eqs1, z0, 0.0, 2pi, _order, _abstol, maxsteps=1)
     @test length(tt) == 2
     @test length(zsol1) == 2
-    tt, zsol1 = taylorinteg(eqs1, z0, 0.0, 2pi, 28, 1.0e-20)
+    tt, zsol1 = taylorinteg(eqs1, z0, 0.0, 2pi, _order, _abstol)
     @test zsol1[1] == z0
     @test isapprox( zsol1[2]  , z0*exp(-tt[2]) )
     @test isapprox( zsol1[end], z0*exp(-tt[end]) )
@@ -37,17 +40,19 @@ end
 @testset "Test integration of ODE with complex dependent variables (2)" begin
     z0 = complex(0.0, 1.0)
     tr = 0.0:pi/8:2pi
-
-    zsol2 = taylorinteg(eqs2, z0, tr, 28, 1.0e-20, maxsteps=1)
+    ts = 0.0:pi:2pi
+    zsol2 = taylorinteg(eqs2, z0, ts, _order, _abstol, maxsteps=1)
+    @test size(zsol2) == (length(ts),)
+    zsol2 = taylorinteg(eqs2, z0, tr, _order, _abstol, maxsteps=1)
     @test length(zsol2) == length(tr)
-    zsol2 = taylorinteg(eqs2, z0, tr, 28, 1.0e-20)
+    zsol2 = taylorinteg(eqs2, z0, tr, _order, _abstol)
     @test zsol2[1] == z0
     @test isapprox( zsol2[3], z0*exp( complex(0.0, tr[3])) )
     @test isapprox( zsol2[5], z0*exp( complex(0.0, tr[5])) )
-    tt, zsol2 = taylorinteg(eqs2, z0, 0.0, 2pi, 28, 1.0e-20, maxsteps=1)
+    tt, zsol2 = taylorinteg(eqs2, z0, 0.0, 2pi, _order, _abstol, maxsteps=1)
     @test length(tt) == 2
     @test length(zsol2) == 2
-    tt, zsol2 = taylorinteg(eqs2, z0, 0.0, 2pi, 28, 1.0e-20)
+    tt, zsol2 = taylorinteg(eqs2, z0, 0.0, 2pi, _order, _abstol)
     @test zsol2[1] == z0
     @test isapprox( zsol2[2], z0*exp( complex(0.0, tt[2])) )
     @test isapprox( zsol2[end], z0*exp( complex(0.0, tt[end])) )
@@ -57,18 +62,20 @@ end
     z0 = complex(0.0, 1.0)
     zz0 = [z0, z0]
     tr = 0.0:pi/8:2pi
-
-    zsol3 = taylorinteg(eqs3!, zz0, tr, 28, 1.0e-20, maxsteps=1)
+    ts = 0.0:pi:2pi
+    zsol3 = taylorinteg(eqs3!, zz0, ts, _order, _abstol, maxsteps=1)
+    @test size(zsol3) == (length(ts), length(zz0))
+    zsol3 = taylorinteg(eqs3!, zz0, tr, _order, _abstol, maxsteps=1)
     @test size(zsol3) == (length(tr), length(zz0))
-    zsol3 = taylorinteg(eqs3!, [z0, z0], tr, 28, 1.0e-20)
+    zsol3 = taylorinteg(eqs3!, [z0, z0], tr, _order, _abstol)
     @test isapprox( zsol3[4,1], z0*exp(-tr[4]) )
     @test isapprox( zsol3[7,1], z0*exp(-tr[7]) )
     @test isapprox( zsol3[4,2], z0*exp( complex(0.0, tr[4])) )
     @test isapprox( zsol3[7,2], z0*exp( complex(0.0, tr[7])) )
-    tt, zsol3 = taylorinteg(eqs3!, zz0, 0.0, 2pi, 28, 1.0e-20, maxsteps=1)
+    tt, zsol3 = taylorinteg(eqs3!, zz0, 0.0, 2pi, _order, _abstol, maxsteps=1)
     @test length(tt) == 2
     @test size(zsol3) == (length(tt), length(zz0))
-    tt, zsol3 = taylorinteg(eqs3!, zz0, 0.0, 2pi, 28, 1.0e-20)
+    tt, zsol3 = taylorinteg(eqs3!, zz0, 0.0, 2pi, _order, _abstol)
     @test zsol3[1,1] == z0
     @test zsol3[1,2] == z0
     @test isapprox( zsol3[2,1], z0*exp( -tt[2]) )

--- a/test/jettransport.jl
+++ b/test/jettransport.jl
@@ -21,14 +21,27 @@ g(t, x) = 0.3x
     tvT1, xvT1 = taylorinteg(f, x0T1, t0, tmax, _order, _abstol)
     tv, xv = taylorinteg(f, x0, t0, tmax, _order, _abstol)
     exactsol(t, x0, t0) = x0/(1.0-x0*(t-t0)) #the analytical solution
-    δsol = exactsol(tvT1[end], x0T1, t0)-xvT1[end]
+    δsol = exactsol(tvT1[end], x0T1, t0)-xvT1[end] #analytical vs jet transport diff at end of integration
     δcoeffs = δsol.coeffs
     @test isapprox(δcoeffs, zeros(6), atol=1e-10, rtol=0)
     @test isapprox(x0, evaluate(xvT1[1]))
     @test isapprox(xv[1], evaluate(xvT1[1]))
     @test isapprox(xv[end], evaluate(xvT1[end]))
+    xvT1_0 = evaluate.(xvT1)
+    @test norm(exactsol.(tvT1, x0, t0)-xvT1_0, Inf) < 1E-12
+    for i in 1:5
+        disp = 0.001*rand() #a small, random displacement
+        x0_disp = x0+disp
+        tv_disp, xv_disp = taylorinteg(f, x0_disp, t0, tmax, _order, _abstol)
+        xvT1_disp = evaluate.(xvT1, disp)
+        @test norm(exactsol.(tvT1, x0_disp, t0)-xvT1_disp, Inf) < 1E-12 #analytical vs jet transport
+        @test norm(x0_disp-evaluate(xvT1[1], disp), Inf) < 1E-12
+        @test norm(xv_disp[1]-evaluate(xvT1[1], disp), Inf) < 1E-12
+        @test norm(xv_disp[end]-evaluate(xvT1[end], disp), Inf) < 1E-12
+    end
 
     y0 = 1.0 #"nominal" initial condition
+    u0 = 0.0 #initial time
     y0T1 = y0 + p #jet transport initial condition
     uvT1, yvT1 = taylorinteg(g, y0T1, t0, 10/0.3, _order, _abstol, maxsteps=1) #warmup lap
     # test maxsteps break
@@ -37,12 +50,24 @@ g(t, x) = 0.3x
     uvT1, yvT1 = taylorinteg(g, y0T1, t0, 10/0.3, _order, _abstol) #Taylor1 jet transport integration
     uv, yv = taylorinteg(g, y0, t0, 10/0.3, _order, _abstol) #reference integration
     exactsol_g(u, y0, u0) = y0*exp(0.3(u-u0))  #the analytical solution
-    δsol_g = exactsol_g(uvT1[end], y0T1, t0)-yvT1[end]
+    δsol_g = exactsol_g(uvT1[end], y0T1, t0)-yvT1[end] #analytical vs jet transport diff at end of integration
     δcoeffs_g = δsol_g.coeffs
     @test isapprox(δcoeffs_g, zeros(6), atol=1e-10, rtol=0)
     @test isapprox(y0, evaluate(yvT1[1]), atol=1e-10, rtol=0)
     @test isapprox(yv[1], evaluate(yvT1[1]), atol=1e-10, rtol=0)
     @test isapprox(yv[end], evaluate(yvT1[end]), atol=1e-10, rtol=0)
+    yvT1_0 = evaluate.(yvT1)
+    @test norm(exactsol_g.(uvT1, y0, u0)-yvT1_0, Inf) < 1E-9
+    for i in 1:5
+        disp = 0.001*rand() #a small, random displacement
+        y0_disp = y0+disp
+        uv_disp, yv_disp = taylorinteg(g, y0_disp, u0, 10/0.3, _order, _abstol)
+        yvT1_disp = evaluate.(yvT1, disp)
+        @test norm(exactsol_g.(uvT1, y0_disp, u0)-yvT1_disp, Inf) < 1E-9 #analytical vs jet transport
+        @test norm(y0_disp-evaluate(yvT1[1], disp), Inf) < 1E-9
+        @test norm(yv_disp[1]-evaluate(yvT1[1], disp), Inf) < 1E-9
+        @test norm(yv_disp[end]-evaluate(yvT1[end], disp), Inf) < 1E-9
+    end
 end
 
 @testset "Test TaylorN jet transport (t0, tmax): 1-dim case" begin
@@ -63,21 +88,48 @@ end
     @test isapprox(x0, evaluate(xvTN[1]))
     @test isapprox(xv[1], evaluate(xvTN[1]))
     @test isapprox(xv[end], evaluate(xvTN[end]))
+    xvTN_0 = evaluate.(xvTN)
+    @test norm(exactsol.(tvTN, x0, t0)-xvTN_0, Inf) < 1E-12
+    for i in 1:5
+        disp = 0.001*rand() #a small, random displacement
+        x0_disp = x0+disp
+        dv = map(x->[disp], tvTN) #a vector of identical displacements
+        tv_disp, xv_disp = taylorinteg(f, x0_disp, t0, tmax, _order, _abstol)
+        xvTN_disp = evaluate.(xvTN, dv)
+        @test norm(exactsol.(tvTN, x0_disp, t0)-xvTN_disp, Inf) < 1E-12 #analytical vs jet transport
+        @test norm(x0_disp-evaluate(xvTN[1], [disp]), Inf) < 1E-12
+        @test norm(xv_disp[1]-evaluate(xvTN[1], [disp]), Inf) < 1E-12
+        @test norm(xv_disp[end]-evaluate(xvTN[end], [disp]), Inf) < 1E-12
+    end
 
     y0 = 1.0 #"nominal" initial condition
+    u0 = 0.0 #initial time
     y0TN = y0 + p[1] #jet transport initial condition
-    uvTN, yvTN = taylorinteg(g, y0TN, t0, 10/0.3, _order, _abstol, maxsteps=1)
+    uvTN, yvTN = taylorinteg(g, y0TN, u0, 10/0.3, _order, _abstol, maxsteps=1)
     @test size(uvTN) == (2,)
     @test size(yvTN) == (2,)
-    uvTN, yvTN = taylorinteg(g, y0TN, t0, 10/0.3, _order, _abstol)
-    uv, yv = taylorinteg(g, y0, t0, 10/0.3, _order, _abstol)
+    uvTN, yvTN = taylorinteg(g, y0TN, u0, 10/0.3, _order, _abstol)
+    uv, yv = taylorinteg(g, y0, u0, 10/0.3, _order, _abstol)
     exactsol_g(u, y0, u0) = y0*exp(0.3(u-u0))
-    δsol_g = exactsol_g(uvTN[end], y0TN, t0)-yvTN[end]
+    δsol_g = exactsol_g(uvTN[end], y0TN, u0)-yvTN[end]
     δcoeffs_g = map(y->y[1], map(x->x.coeffs, δsol_g.coeffs))
     @test isapprox(δcoeffs_g, zeros(6), atol=1e-10, rtol=0)
     @test isapprox(y0, evaluate(yvTN[1]), atol=1e-10, rtol=0)
     @test isapprox(yv[1], evaluate(yvTN[1]), atol=1e-10, rtol=0)
     @test isapprox(yv[end], evaluate(yvTN[end]), atol=1e-10, rtol=0)
+    yvTN_0 = evaluate.(yvTN)
+    @test norm(exactsol_g.(uvTN, y0, u0)-yvTN_0, Inf) < 1E-9
+    for i in 1:5
+        disp = 0.001*rand() #a small, random displacement
+        y0_disp = y0+disp
+        dv = map(x->[disp], uvTN) #a vector of identical displacements
+        uv_disp, yv_disp = taylorinteg(g, y0_disp, u0, 10/0.3, _order, _abstol)
+        yvTN_disp = evaluate.(yvTN, dv)
+        @test norm(exactsol_g.(uvTN, y0_disp, u0)-yvTN_disp, Inf) < 1E-9 #analytical vs jet transport
+        @test norm(y0_disp-evaluate(yvTN[1], [disp]), Inf) < 1E-9
+        @test norm(yv_disp[1]-evaluate(yvTN[1], [disp]), Inf) < 1E-9
+        @test norm(yv_disp[end]-evaluate(yvTN[end], [disp]), Inf) < 1E-9
+    end
 end
 
 @testset "Test Taylor1 jet transport (trange): 1-dim case" begin
@@ -101,7 +153,8 @@ end
         disp = 0.001*rand() #a small, random displacement
         xv_disp = taylorinteg(f, x0+disp, tv, _order, _abstol)
         xvT1_disp = evaluate.(xvT1, disp)
-        @test isapprox(xv_disp, xvT1_disp)
+        @test norm(exactsol.(tv, x0+disp, tv[1])-xvT1_disp, Inf) < 1E-12 #analytical vs jet transport
+        @test norm(xv_disp-xvT1_disp, Inf) < 1E-12 # integration vs jet transport
     end
 
     y0 = 1.0 #"nominal" initial condition
@@ -123,7 +176,8 @@ end
         disp = 0.001*rand() #a small, random displacement
         yv_disp = taylorinteg(g, y0+disp, uv, _order, _abstol)
         yvT1_disp = evaluate.(yvT1, disp)
-        @test isapprox(yv_disp, yvT1_disp)
+        @test norm(exactsol_g.(uv, y0+disp, uv[1])-yvT1_disp, Inf) < 1E-9 #analytical vs jet transport
+        @test norm(yv_disp-yvT1_disp, Inf) < 1E-9 # integration vs jet transport
     end
 end
 
@@ -144,6 +198,14 @@ end
     xv_analytical = exactsol.(tv, x0, tv[1])
     xvTN_0 = evaluate.(xvTN)
     @test isapprox(xv_analytical, xvTN_0, atol=1e-10, rtol=0)
+    for i in 1:5
+        disp = 0.001*rand() #a small, random displacement
+        dv = map(x->[disp], tv) #a vector of identical displacements
+        xv_disp = taylorinteg(f, x0+disp, tv, _order, _abstol)
+        xvTN_disp = evaluate.(xvTN, dv)
+        @test norm(exactsol.(tv, x0+disp, tv[1])-xvTN_disp, Inf) < 1E-12 #analytical vs jet transport
+        @test norm(xv_disp-xvTN_disp, Inf) < 1E-12 # integration vs jet transport
+    end
 
     y0 = 1.0 #"nominal" initial condition
     y0TN = y0 + p[1] #jet transport initial condition
@@ -160,6 +222,14 @@ end
     yv_analytical = exactsol_g.(uv, y0, uv[1])
     yvTN_0 = evaluate.(yvTN)
     @test isapprox(yv_analytical, yvTN_0, atol=1e-10, rtol=0)
+    for i in 1:5
+        disp = 0.001*rand() #a small, random displacement
+        dv = map(x->[disp], uv) #a vector of identical displacements
+        yv_disp = taylorinteg(g, y0+disp, uv, _order, _abstol)
+        yvTN_disp = evaluate.(yvTN, dv)
+        @test norm(exactsol_g.(uv, y0+disp, uv[1])-yvTN_disp, Inf) < 1E-9 #analytical vs jet transport
+        @test norm(yv_disp-yvTN_disp, Inf) < 1E-9 # integration vs jet transport
+    end
 end
 
 @testset "Test TaylorN jet transport (t0,tmax): harmonic oscillator" begin

--- a/test/jettransport.jl
+++ b/test/jettransport.jl
@@ -308,8 +308,11 @@ end
     p = set_variables("ξ", numvars=2, order=5)
     x0 = [-1.0,0.45]
     x0TN = x0 + p
+    tvTN, xvTN = taylorinteg(harmosc!, x0TN, 0.0, 10pi, _order, _abstol, maxsteps=1)
+    @test length(tvTN) == 2
+    @test size(xvTN) == (length(tvTN), length(x0TN))
     tvTN, xvTN = taylorinteg(harmosc!, x0TN, 0.0, 10pi, _order, _abstol)
-    tv  , xv   = taylorinteg(harmosc!, x0  , 0.0, 10pi, _order, _abstol)
+    tv , xv = taylorinteg(harmosc!, x0  , 0.0, 10pi, _order, _abstol)
     x_analyticsol(t,x0,p0) = p0*sin(t)+x0*cos(t)
     p_analyticsol(t,x0,p0) = p0*cos(t)-x0*sin(t)
     x_δsol = x_analyticsol(tvTN[end], x0TN[1], x0TN[2])-xvTN[end,1]

--- a/test/jettransport.jl
+++ b/test/jettransport.jl
@@ -10,7 +10,7 @@ f(t, x) = x^2
 g(t, x) = 0.3x
 
 @testset "Test Taylor1 jet transport (t0, tmax): 1-dim case" begin
-    p = Taylor1(5)
+    p = Taylor1([0.0,1.0], 5)
     x0 = 3.0 #"nominal" initial condition
     x0T1 = x0 + p #jet transport initial condition
     t0=0.0
@@ -133,7 +133,7 @@ end
 end
 
 @testset "Test Taylor1 jet transport (trange): 1-dim case" begin
-    p = Taylor1(5)
+    p = Taylor1([0.0,1.0], 5)
     x0 = 3.0 #"nominal" initial condition
     x0T1 = x0 + p #jet transport initial condition
     tv = 0.0:0.05:0.33

--- a/test/lyapunov.jl
+++ b/test/lyapunov.jl
@@ -26,7 +26,7 @@ const _abstol = 1.0E-20
     end
 end
 
-@testset "Test `classicalGS!`, `modifiedGS!`" begin
+@testset "Test `classicalGS!`" begin
     dof = 3
     jt = rand(dof,dof)
     QH = Array{eltype(jt)}(dof,dof)

--- a/test/lyapunov.jl
+++ b/test/lyapunov.jl
@@ -41,7 +41,7 @@ end
             if j == i
                 @test isapprox( dot(QH[:,i],QH[:,j]), one(eltype(jt)) )
             else
-                @test abs( dot(QH[:,i],QH[:,j]) ) < 1E-14
+                @test abs( dot(QH[:,i],QH[:,j]) ) < 1E-10
             end
         end
     end


### PR DESCRIPTION
This PR enables the user to use `Taylor1{T}` variables as initial conditions. This is useful, for example, for one-variational jet transport, which can already be done with 1-variable `TaylorN{T}`s, but using `Taylor1{T}` is faster.

EDIT: Additionally, this PR is aiming toward 100% testing coverage for TaylorIntegration.jl!