### PR TITLE
Small fix for time (independent variable)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,10 +1,7 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 
 branches:

--- a/src/TaylorIntegration.jl
+++ b/src/TaylorIntegration.jl
@@ -4,7 +4,7 @@ module TaylorIntegration
 
 using TaylorSeries
 
-export  taylorinteg, liap_taylorinteg
+export taylorinteg, liap_taylorinteg
 
 include("explicitode.jl")
 

--- a/src/explicitode.jl
+++ b/src/explicitode.jl
@@ -68,8 +68,9 @@ function jetcoeffs!{T<:Real, U<:Number}(eqsdiff!, t::Taylor1{T}, x::Vector{Taylo
     for ord in 1:order
         ordnext = ord+1
 
-        # Set `taux` and `xaux`, auxiliary vector of Taylor1 to order `ord`
+        # Set `taux`, auxiliary Taylor1 variable to order `ord`
         @inbounds taux = Taylor1( t.coeffs[1:ord] )
+        # Set xaux`, auxiliary vector of Taylor1 to order `ord`
         for j in eachindex(x)
             @inbounds xaux[j] = Taylor1( x[j].coeffs[1:ord] )
         end
@@ -276,8 +277,8 @@ function taylorinteg{T<:Real, U<:Number}(f, x0::U, t0::T, tmax::T, order::Int,
     const xv = Array{U}(maxsteps+1)
 
     # Initialize the Taylor1 expansions
-    const x = Taylor1( x0, order )
     const t = Taylor1( T, order )
+    const x = Taylor1( x0, order )
 
     # Initial conditions
     nsteps = 1
@@ -315,7 +316,7 @@ function taylorinteg{T<:Real, U<:Number}(f!, q0::Array{U,1}, t0::T, tmax::T,
     const xv = Array{U}(dof, maxsteps+1)
 
     # Initialize the vector of Taylor1 expansions
-    const t = Taylor1( T, order )
+    const t = Taylor1(T, order)
     const x = Array{Taylor1{U}}(dof)
     const dx = Array{Taylor1{U}}(dof)
     const xaux = Array{Taylor1{U}}(dof)
@@ -428,8 +429,8 @@ function taylorinteg{T<:Real, U<:Number}(f, x0::U, trange::Range{T},
     fill!(xv, T(NaN))
 
     # Initialize the Taylor1 expansions
-    const x = Taylor1( x0, order )
     const t = Taylor1( T, order )
+    const x = Taylor1( x0, order )
 
     # Initial conditions
     @inbounds t[1] = trange[1]
@@ -473,9 +474,9 @@ function taylorinteg{T<:Real, U<:Number}(f!, q0::Array{U,1}, trange::Range{T},
     for ind in 1:nn
         @inbounds xv[:,ind] .= x0
     end
-    const t = Taylor1( T, order )
 
     # Initialize the vector of Taylor1 expansions
+    const t = Taylor1( T, order )
     const x = Array{Taylor1{U}}(dof)
     const dx = Array{Taylor1{U}}(dof)
     const xaux = Array{Taylor1{U}}(dof)

--- a/test/lyapunov.jl
+++ b/test/lyapunov.jl
@@ -21,7 +21,7 @@ const _abstol = 1.0E-20
         δx = [ x0[1]+xi[1], x0[2]+xi[2], x0[3]+xi[3] ]
         dδx = similar(δx)
         lorenzjac = Array{eltype(x0)}(3,3)
-        TaylorIntegration.stabilitymatrix!(lorenz!, t0, x0, δx, dδx, lorenzjac)
+        TaylorIntegration.stabilitymatrix!(lorenz!, t0, view(x0,:), δx, dδx, lorenzjac)
         @test trace(lorenzjac) == -(σ+one(Float64)+β)
     end
 end

--- a/test/many_ode.jl
+++ b/test/many_ode.jl
@@ -5,8 +5,7 @@ using Base.Test
 
 const _order = 28
 const _abstol = 1.0E-20
-const vT = zeros(_order+1)
-vT[2] = 1.0
+const tT = Taylor1(_order)
 
 @testset "Tests: dot{x}=x.^2, x(0) = [3.0,1.0]" begin
     function eqs_mov!(t, x, Dx)
@@ -21,8 +20,8 @@ vT[2] = 1.0
     q0T = [Taylor1(q0[1], _order), Taylor1(q0[2], _order)]
     xdotT = Array{Taylor1{Float64}}(length(q0))
     xaux = Array{Taylor1{Float64}}(length(q0))
-    vT[1] = t0
-    TaylorIntegration.jetcoeffs!(eqs_mov!, t0, q0T, xdotT, xaux, vT)
+    tT[1] = t0
+    TaylorIntegration.jetcoeffs!(eqs_mov!, tT, q0T, xdotT, xaux)
     @test q0T[1].coeffs[end] == 3.0^(_order+1)
     @test q0T[2].coeffs[end] == 1.0
     δt = (_abstol/q0T[1].coeffs[end-1])^inv(_order-1)

--- a/test/many_ode.jl
+++ b/test/many_ode.jl
@@ -56,26 +56,26 @@ end
     abstol = 1e-20
     order = 25
     x0 = [t0, 0.0] #initial conditions such that x(t)=sin(t)
-    tT, xT = taylorinteg(f!, x0, t0, tmax, order, abstol)
-    @test length(tT) < 501
-    @test length(xT[:,1]) < 501
-    @test length(xT[:,2]) < 501
-    @test xT[1,1:end] == x0
-    @test tT[1] == t0
-    @test xT[1,1] == x0[1]
-    @test xT[1,2] == x0[2]
-    @test tT[end] == xT[end,1]
-    @test abs(sin(tmax)-xT[end,2]) < 1e-14
+    tv, xv = taylorinteg(f!, x0, t0, tmax, order, abstol)
+    @test length(tv) < 501
+    @test length(xv[:,1]) < 501
+    @test length(xv[:,2]) < 501
+    @test xv[1,1:end] == x0
+    @test tv[1] == t0
+    @test xv[1,1] == x0[1]
+    @test xv[1,2] == x0[2]
+    @test tv[end] == xv[end,1]
+    @test abs(sin(tmax)-xv[end,2]) < 1e-14
 
     tmax = 15*(2pi)
-    tT, xT = taylorinteg(f!, x0, t0, tmax, order, abstol)
-    @test length(tT) < 501
-    @test length(xT[:,1]) < 501
-    @test length(xT[:,2]) < 501
-    @test xT[1,1:end] == x0
-    @test tT[1] == t0
-    @test xT[1,1] == x0[1]
-    @test xT[1,2] == x0[2]
-    @test tT[end] == xT[end,1]
-    @test abs(sin(tmax)-xT[end,2]) < 1e-14
+    tv, xv = taylorinteg(f!, x0, t0, tmax, order, abstol)
+    @test length(tv) < 501
+    @test length(xv[:,1]) < 501
+    @test length(xv[:,2]) < 501
+    @test xv[1,1:end] == x0
+    @test tv[1] == t0
+    @test xv[1,1] == x0[1]
+    @test xv[1,2] == x0[2]
+    @test tv[end] == xv[end,1]
+    @test abs(sin(tmax)-xv[end,2]) < 1e-14
 end

--- a/test/one_ode.jl
+++ b/test/one_ode.jl
@@ -5,16 +5,15 @@ using Base.Test
 
 const _order = 28
 const _abstol = 1.0E-20
-const vT = zeros(_order+1)
-vT[2] = 1.0
+const tT = Taylor1(_order)
 
 @testset "Tests: dot{x}=x^2, x(0) = 1" begin
     eqs_mov(t, x) = x^2
     t0 = 0.0
     x0 = 1.0
     x0T = Taylor1(x0, _order)
-    vT[1] = t0
-    TaylorIntegration.jetcoeffs!(eqs_mov, t0, x0T, vT)
+    tT[1] = t0
+    TaylorIntegration.jetcoeffs!(eqs_mov, tT, x0T)
     @test x0T.coeffs[end] == 1.0
     δt = _abstol^inv(_order-1)
     @test TaylorIntegration.stepsize(x0T, _abstol) == δt
@@ -42,8 +41,8 @@ end
     x0 = 3.0
     q0 = [3.0, 3.0]
     x0T = Taylor1(x0, _order)
-    vT[1] = t0
-    TaylorIntegration.jetcoeffs!(eqs_mov, t0, x0T, vT)
+    tT[1] = t0
+    TaylorIntegration.jetcoeffs!(eqs_mov, tT, x0T)
     @test x0T.coeffs[end] == 3.0^(_order+1)
     δt = (_abstol/x0T.coeffs[end-1])^inv(_order-1)
     @test TaylorIntegration.stepsize(x0T, _abstol) == δt
@@ -107,24 +106,24 @@ end
 end
 
 @testset "Test non-autonomous ODE (1): dot{x}=cos(t)" begin
-    f!(t, x) = cos(t)
+    f(t, x) = cos(t)
     t0 = 0//1
     tmax = 10.25*(2pi)
     abstol = 1e-20
     order = 25
     x0 = 0.0 #initial conditions such that x(t)=sin(t)
-    tT, xT = taylorinteg(f!, x0, t0, tmax, order, abstol)
-    @test length(tT) < 501
-    @test length(xT) < 501
+    tv, xv = taylorinteg(f, x0, t0, tmax, order, abstol)
+    @test length(tv) < 501
+    @test length(xv) < 501
     # @test length(xT[:,2]) < 501
-    @test xT[1] == x0
-    @test tT[1] == t0
-    @test abs(sin(tmax)-xT[end]) < 1e-14
+    @test xv[1] == x0
+    @test tv[1] == t0
+    @test abs(sin(tmax)-xv[end]) < 1e-14
 
     tmax = 15*(2pi)
-    tT, xT = taylorinteg(f!, x0, t0, tmax, order, abstol)
-    @test length(tT) < 501
-    @test length(xT) < 501
-    @test xT[1] == x0
-    @test abs(sin(tmax)-xT[end]) < 1e-14
+    tv, xv = taylorinteg(f, x0, t0, tmax, order, abstol)
+    @test length(tv) < 501
+    @test length(xv) < 501
+    @test xv[1] == x0
+    @test abs(sin(tmax)-xv[end]) < 1e-14
 end


### PR DESCRIPTION
This PR represents a new version of the changes introduced in #25; i.e., a small fix for how the independent variable is handled internally. The independent variable is now represented by a `Taylor1{T}` in `jetcoeffs!`, `taylorstep!` and `taylorinteg`, instead of a `Vector{T}`. This should also make life a bit easier for #31 and give a consistent API throughout. Tests are passing locally in julia 0.5.2, 0.6.0 and 0.7.0-DEV.1599