### PR TITLE
Deal with recent breaking changes on julia nightlies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,9 @@ notifications:
 
 ## uncomment the following lines to allow failures on nightly julia
 ## (tests will run but not make your overall status red)
-matrix:
- allow_failures:
- - julia: nightly
+# matrix:
+#  allow_failures:
+#  - julia: nightly
 
 script:
  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,28 @@
 # Documentation: http://docs.travis-ci.com/user/languages/julia/
 language: julia
+
 os:
   - linux
   - osx
+
 julia:
   - 0.5
   - 0.6
   - nightly
+
 notifications:
   email: false
+
+## uncomment the following lines to allow failures on nightly julia
+## (tests will run but not make your overall status red)
+matrix:
+ allow_failures:
+ - julia: nightly
+
 script:
  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
  - julia -e 'Pkg.clone(pwd()); Pkg.build("TaylorIntegration"); Pkg.test("TaylorIntegration"; coverage=true)'
+
 after_success:
   # push coverage results to Coveralls
   - julia -e 'cd(Pkg.dir("TaylorIntegration")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,10 +6,10 @@ environment:
 
 ## uncomment the following lines to allow failures on nightly julia
 ## (tests will run but not make your overall status red)
-matrix:
-  allow_failures:
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+# matrix:
+#   allow_failures:
+#   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
+#   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 
 notifications:
   - provider: Email

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,3 +39,4 @@ build_script:
 
 test_script:
   - C:\projects\julia\bin\julia --check-bounds=yes -e "Pkg.test(\"TaylorIntegration\")"
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,11 +11,6 @@ matrix:
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 
-branches:
-  only:
-    - master
-    - /release-.*/
-
 notifications:
   - provider: Email
     on_build_success: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,3 +40,4 @@ build_script:
 test_script:
   - C:\projects\julia\bin\julia --check-bounds=yes -e "Pkg.test(\"TaylorIntegration\")"
 
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,13 @@ environment:
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 
+## uncomment the following lines to allow failures on nightly julia
+## (tests will run but not make your overall status red)
+matrix:
+  allow_failures:
+  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
+  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+
 branches:
   only:
     - master

--- a/test/bigfloats.jl
+++ b/test/bigfloats.jl
@@ -1,5 +1,11 @@
+# This file is part of the TaylorIntegration.jl package; MIT licensed
+
 using TaylorSeries, TaylorIntegration
-using Base.Test
+if VERSION < v"0.7.0-DEV.2004"
+    using Base.Test
+else
+   using Test
+end
 
 const _order = 90
 const _abstol = 1.0E-77

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -1,7 +1,11 @@
 # This file is part of the TaylorIntegration.jl package; MIT licensed
 
 using TaylorSeries, TaylorIntegration
-using Base.Test
+if VERSION < v"0.7.0-DEV.2004"
+    using Base.Test
+else
+   using Test
+end
 
 const _order = 28
 const _abstol = 1.0E-20

--- a/test/jettransport.jl
+++ b/test/jettransport.jl
@@ -1,7 +1,11 @@
 # This file is part of the TaylorIntegration.jl package; MIT licensed
 
 using TaylorSeries, TaylorIntegration
-using Base.Test
+if VERSION < v"0.7.0-DEV.2004"
+    using Base.Test
+else
+   using Test
+end
 
 const _order = 28
 const _abstol = 1.0E-20

--- a/test/lyapunov.jl
+++ b/test/lyapunov.jl
@@ -1,7 +1,11 @@
 # This file is part of the TaylorIntegration.jl package; MIT licensed
 
 using TaylorSeries, TaylorIntegration
-using Base.Test
+if VERSION < v"0.7.0-DEV.2004"
+    using Base.Test
+else
+   using Test
+end
 
 const _order = 28
 const _abstol = 1.0E-20

--- a/test/many_ode.jl
+++ b/test/many_ode.jl
@@ -1,7 +1,11 @@
 # This file is part of the TaylorIntegration.jl package; MIT licensed
 
 using TaylorSeries, TaylorIntegration
-using Base.Test
+if VERSION < v"0.7.0-DEV.2004"
+    using Base.Test
+else
+   using Test
+end
 
 const _order = 28
 const _abstol = 1.0E-20

--- a/test/one_ode.jl
+++ b/test/one_ode.jl
@@ -1,7 +1,11 @@
 # This file is part of the TaylorIntegration.jl package; MIT licensed
 
 using TaylorSeries, TaylorIntegration
-using Base.Test
+if VERSION < v"0.7.0-DEV.2004"
+     using Base.Test
+else
+    using Test
+end
 
 const _order = 28
 const _abstol = 1.0E-20


### PR DESCRIPTION
~This PR modifies `.travis.yml` and `appveyor.yml` so that builds can fail on julia nightlies without marking the overall build as failing. This is a temporary solution, until we find a better way to deal with recent breaking changes on julia 0.7.0-DEV~

EDIT: This PR deals with recent changes introduced by JuliaLang/julia#23876, which corresponds to julia build `v"0.7.0-DEV.2004"` (according to `commit-name.sh`), and following the discussion and a suggestion by @lbenet in JuliaDiff/TaylorSeries.jl#128, I'm proposing to follow that strategy to deal with such changes
