### PR TITLE
add common interface bindings

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,4 @@
 julia 0.6
 TaylorSeries 0.7.0
+Reexport
+DiffEqBase

--- a/src/TaylorIntegration.jl
+++ b/src/TaylorIntegration.jl
@@ -4,10 +4,25 @@ module TaylorIntegration
 
 using TaylorSeries
 
+using Reexport
+@reexport using DiffEqBase
+
+const warnkeywords =
+    (:save_idxs, :d_discontinuities, :unstable_check, :save_everystep,
+     :save_end, :initialize_save, :adaptive, :dt, :reltol, :dtmax,
+     :dtmin, :force_dtmin, :internalnorm, :gamma, :beta1, :beta2,
+     :qmax, :qmin, :qsteady_min, :qsteady_max, :qoldinit, :failfactor,
+     :maxiters, :isoutofdomain, :unstable_check,
+     :calck, :progress, :timeseries_steps, :tstops, :saveat, :dense)
+
+function __init__()
+    const global warnlist = Set(warnkeywords)
+end
+
 export taylorinteg, liap_taylorinteg
 
 include("explicitode.jl")
-
 include("liapunovspectrum.jl")
+include("common.jl")
 
 end #module

--- a/src/common.jl
+++ b/src/common.jl
@@ -62,8 +62,6 @@ function DiffEqBase.solve{uType,tType,isinplace,AlgType<:TaylorAlgorithm}(
       _timeseries = vec(vectimeseries)
     end
 
-    _t,_timeseries
-
     build_solution(prob,  alg, _t, _timeseries,
                    timeseries_errors = timeseries_errors,
                    retcode = :Success)

--- a/src/common.jl
+++ b/src/common.jl
@@ -1,0 +1,70 @@
+abstract type TaylorAlgorithm <: DEAlgorithm end
+struct TaylorMethod <: TaylorAlgorithm
+    order::Int
+end
+
+TaylorMethod() = error("Maximum order must be specified for the Taylor method")
+
+export TaylorMethod
+
+function DiffEqBase.solve{uType,tType,isinplace,AlgType<:TaylorAlgorithm}(
+    prob::AbstractODEProblem{uType,tType,isinplace},
+    alg::AlgType,
+    timeseries=[],ts=[],ks=[];
+    verbose=true, abstol = 1e-6, save_start = true,
+    timeseries_errors=true, maxiters = 1000000,
+    callback=nothing, kwargs...)
+
+    if verbose
+        warned = !isempty(kwargs) && check_keywords(alg, kwargs, warnlist)
+        warned && warn_compat()
+    end
+
+    if prob.callback != nothing || callback != nothing
+        error("TaylorIntegration is not compatible with callbacks.")
+    end
+
+    if typeof(prob.u0) <: Number
+        u0 = [prob.u0]
+    else
+        u0 = vec(deepcopy(prob.u0))
+    end
+
+    sizeu = size(prob.u0)
+
+    if !isinplace && (typeof(prob.u0)<:Vector{Float64} || typeof(prob.u0)<:Number)
+        f! = (t, u, du) -> (du .= prob.f(t, u); 0)
+    elseif !isinplace && typeof(prob.u0)<:AbstractArray
+        f! = (t, u, du) -> (du .= vec(prob.f(t, reshape(u, sizeu))); 0)
+    elseif typeof(prob.u0)<:Vector{Float64}
+        f! = prob.f
+    else # Then it's an in-place function on an abstract array
+        f! = (t, u, du) -> (prob.f(t, reshape(u, sizeu),reshape(du, sizeu));
+                            u = vec(u); du=vec(du); 0)
+    end
+
+    t,vectimeseries = taylorinteg(f!, u0, prob.tspan[1], prob.tspan[2], alg.order,
+                                                      abstol, maxsteps=maxiters)
+
+    if save_start
+      start_idx = 1
+      _t = t
+    else
+      start_idx = 2
+      _t = t[2:end]
+    end
+    if typeof(prob.u0) <: AbstractArray
+      _timeseries = Vector{uType}(0)
+      for i=start_idx:size(vectimeseries, 1)
+          push!(_timeseries, reshape(view(vectimeseries, i, :, )', sizeu))
+      end
+    else
+      _timeseries = vec(vectimeseries)
+    end
+
+    _t,_timeseries
+
+    build_solution(prob,  alg, _t, _timeseries,
+                   timeseries_errors = timeseries_errors,
+                   retcode = :Success)
+end

--- a/test/common.jl
+++ b/test/common.jl
@@ -5,7 +5,7 @@ using TaylorIntegration, Base.Test
     u0 = 0.5
     tspan = (0.0,1.0)
     prob = ODEProblem(f,u0,tspan)
-    sol = solve(prob,TaylorMethod(50))
+    sol = solve(prob,TaylorMethod(50),abstol=1e-20)
 
     @test sol[end] - 0.5exp(1) < 1e-12
 end
@@ -15,7 +15,7 @@ end
     u0 = rand(4,2)
     tspan = (0.0,1.0)
     prob = ODEProblem(f,u0,tspan)
-    sol = solve(prob,TaylorMethod(50))
+    sol = solve(prob,TaylorMethod(50),abstol=1e-20)
 
     @test norm(sol[end] - u0.*exp(1)) < 1e-12
 end

--- a/test/common.jl
+++ b/test/common.jl
@@ -1,0 +1,21 @@
+using TaylorIntegration, Base.Test
+
+@testset "Test integration of ODE with numbers in common interface" begin
+    f(t,u) = u
+    u0 = 0.5
+    tspan = (0.0,1.0)
+    prob = ODEProblem(f,u0,tspan)
+    sol = solve(prob,TaylorMethod(50))
+
+    @test sol[end] - 0.5exp(1) < 1e-12
+end
+
+@testset "Test integration of ODE with abstract arrays in common interface" begin
+    f(t,u,du) = (du .= u)
+    u0 = rand(4,2)
+    tspan = (0.0,1.0)
+    prob = ODEProblem(f,u0,tspan)
+    sol = solve(prob,TaylorMethod(50))
+
+    @test norm(sol[end] - u0.*exp(1)) < 1e-12
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,7 +6,8 @@ testfiles = (
     "complex.jl",
     "jettransport.jl",
     "lyapunov.jl",
-    "bigfloats.jl"
+    "bigfloats.jl",
+    "common.jl"
     )
 
 for file in testfiles


### PR DESCRIPTION
This adds common interface bindings (#19) so that 

```julia
sol = solve(prob,TaylorMethod(50))
```

calls the Taylor method from this package with maximum order set to 50. There's definitely more that can be done integrating the two packages, but this is a good and usable first step.