### PR TITLE
Some improvements in Lyapunov spectrum computation and other minor stuff

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.6
-TaylorSeries 0.7.1
+TaylorSeries 0.7.2
 Reexport
 DiffEqBase

--- a/src/TaylorIntegration.jl
+++ b/src/TaylorIntegration.jl
@@ -2,10 +2,8 @@
 
 module TaylorIntegration
 
-using TaylorSeries
-
 using Reexport
-@reexport using DiffEqBase
+@reexport using TaylorSeries, DiffEqBase
 
 const warnkeywords =
     (:save_idxs, :d_discontinuities, :unstable_check, :save_everystep,

--- a/src/explicitode.jl
+++ b/src/explicitode.jl
@@ -70,7 +70,7 @@ function jetcoeffs!(eqsdiff!, t::Taylor1{T}, x::Vector{Taylor1{U}},
 
         # Set `taux`, auxiliary Taylor1 variable to order `ord`
         @inbounds taux = Taylor1( t.coeffs[1:ordnext] )
-        # Set xaux`, auxiliary vector of Taylor1 to order `ord`
+        # Set `xaux`, auxiliary vector of Taylor1 to order `ord`
         for j in eachindex(x)
             @inbounds xaux[j] = Taylor1( x[j].coeffs[1:ordnext] )
         end

--- a/src/liapunovspectrum.jl
+++ b/src/liapunovspectrum.jl
@@ -160,8 +160,11 @@ end
     liap_taylorinteg(f, q0, t0, tmax, order, abstol; maxsteps::Int=500)
 
 Similar to [`taylorinteg!`](@ref) for the calculation of the Liapunov
-spectrum. Whenever `length(q0) != TaylorSeries.get_numvars()`, then
-`liap_taylorinteg` changes globally some internal parameters of TaylorN.
+spectrum. Note that the number of `TaylorN` variables should be set
+previously by the user (e.g., by means of `TaylorSeries.set_variables`) and
+should be equal to the length of the vector of initial conditions `q0`.
+Otherwise, whenever `length(q0) != TaylorSeries.get_numvars()`, then
+`liap_taylorinteg` throws an `AssertionError`.
 
 """
 function liap_taylorinteg(f, q0::Array{U,1}, t0::T, tmax::T,
@@ -175,13 +178,10 @@ function liap_taylorinteg(f, q0::Array{U,1}, t0::T, tmax::T,
     const jt = eye(U, dof)
     const _δv = Array{TaylorN{Taylor1{U}}}(dof)
 
-    if get_numvars() == dof
-        for ind in eachindex(q0)
-            _δv[ind] = TaylorN(Taylor1{U},ind,order=1)
-        end
-    else
-        # NOTE: This changes GLOBALLY internal parameters of TaylorN
-        _δv = set_variables(Taylor1{U}, "δ", order=1, numvars=dof)
+    @assert get_numvars() == dof "`length(q0)` must be equal to number of variables set by `TaylorN`"
+
+    for ind in eachindex(q0)
+        _δv[ind] = TaylorN(Taylor1{U},ind,order=1)
     end
 
     # Initial conditions
@@ -263,13 +263,10 @@ function liap_taylorinteg(f, q0::Array{U,1}, trange::Union{Range{T},Vector{T}},
     const jt = eye(U, dof)
     const _δv = Array{TaylorN{Taylor1{U}}}(dof)
 
-    if get_numvars() == dof
-        for ind in eachindex(q0)
-            _δv[ind] = TaylorN(Taylor1{U},ind,order=1)
-        end
-    else
-        # NOTE: This changes GLOBALLY internal parameters of TaylorN
-        _δv = set_variables(Taylor1{U}, "δ", order=1, numvars=dof)
+    @assert get_numvars() == dof "`length(q0)` must be equal to number of variables set by `TaylorN`"
+
+    for ind in eachindex(q0)
+        _δv[ind] = TaylorN(Taylor1{U},ind,order=1)
     end
 
     # Initial conditions

--- a/src/liapunovspectrum.jl
+++ b/src/liapunovspectrum.jl
@@ -9,13 +9,13 @@ at `x`; `x` is of type `Vector{T<:Number}`. `δx` and `dδx` are two
 auxiliary arrays of type `Vector{TaylorN{T}}` to avoid allocations.
 
 """
-function stabilitymatrix!(eqsdiff!, t0::T,
-        x::SubArray{U,1}, δx::Array{TaylorN{U},1},
-        dδx::Array{TaylorN{U},1}, jac::Array{U,2}) where {T<:Real, U<:Number}
+function stabilitymatrix!(eqsdiff!, t::Taylor1{T},
+        x::SubArray{Taylor1{U},1}, δx::Array{TaylorN{Taylor1{U}},1},
+        dδx::Array{TaylorN{Taylor1{U}},1}, jac::Array{Taylor1{U},2}) where {T<:Real, U<:Number}
     for ind in eachindex(x)
-        @inbounds δx[ind] = x[ind] + TaylorN(U,ind,order=1)
+        @inbounds δx[ind] = x[ind] + TaylorN(Taylor1{U},ind,order=1)
     end
-    eqsdiff!(t0, δx, dδx)
+    eqsdiff!(t, δx, dδx)
     jacobian!( jac, dδx )
     nothing
 end
@@ -117,7 +117,7 @@ function liap_jetcoeffs!(eqsdiff!, t::Taylor1{T}, x::Vector{Taylor1{U}},
 
         # Equations of motion
         eqsdiff!(taux, xaux, dx)
-        stabilitymatrix!( eqsdiff!, t[0], view(xaux,1:dof), δx, dδx, jac )
+        stabilitymatrix!( eqsdiff!, t, view(xaux,1:dof), δx, dδx, jac )
         @inbounds dx[dof+1:nx] = jac * reshape( xaux[dof+1:nx], (dof,dof) )
 
         # Recursion relations

--- a/src/liapunovspectrum.jl
+++ b/src/liapunovspectrum.jl
@@ -116,8 +116,15 @@ function liap_jetcoeffs!(eqsdiff!, t::Taylor1{T}, x::Vector{Taylor1{U}},
         end
 
         # Equations of motion
-        eqsdiff!(taux, xaux, dx)
-        stabilitymatrix!( eqsdiff!, t, view(xaux,1:dof), δx, dδx, jac )
+        # eqsdiff!(taux, xaux, dx)
+        # stabilitymatrix!( eqsdiff!, t, view(xaux,1:dof), δx, dδx, jac )
+        for ind in 1:dof
+            @inbounds δx[ind] = xaux[ind] + TaylorN(Taylor1{U},ind,order=1)
+        end
+        eqsdiff!(taux, δx, dδx)
+        jacobian!(jac, dδx)
+        @inbounds dx[1:dof] .= constant_term.(dδx)
+        #############
         @inbounds dx[dof+1:nx] = jac * reshape( xaux[dof+1:nx], (dof,dof) )
 
         # Recursion relations

--- a/src/liapunovspectrum.jl
+++ b/src/liapunovspectrum.jl
@@ -160,7 +160,8 @@ end
     liap_taylorinteg(f, q0, t0, tmax, order, abstol; maxsteps::Int=500)
 
 Similar to [`taylorinteg!`](@ref) for the calculation of the Liapunov
-spectrum.
+spectrum. Whenever `length(q0) != TaylorSeries.get_numvars()`, then
+`liap_taylorinteg` changes globally some internal parameters of TaylorN.
 
 """
 function liap_taylorinteg(f, q0::Array{U,1}, t0::T, tmax::T,

--- a/src/liapunovspectrum.jl
+++ b/src/liapunovspectrum.jl
@@ -113,14 +113,13 @@ function liap_jetcoeffs!(eqsdiff!, t::Taylor1{T}, x::Vector{Taylor1{U}},
         end
 
         # Equations of motion
-        # stabilitymatrix!( eqsdiff!, t, view(xaux,1:dof), δx, dδx, jac )
         for ind in eachindex(δx)
             @inbounds δx[ind] = xaux[ind] + _δv[ind]
         end
         eqsdiff!(taux, δx, dδx)
-        jacobian!(jac, dδx)
         @inbounds dx[1:dof] .= constant_term.(dδx)
-        #############
+        # Stability matrix
+        jacobian!(jac, dδx)
         @inbounds dx[dof+1:nx] = jac * reshape( xaux[dof+1:nx], (dof,dof) )
 
         # Recursion relations

--- a/src/liapunovspectrum.jl
+++ b/src/liapunovspectrum.jl
@@ -114,7 +114,7 @@ function liap_jetcoeffs!(eqsdiff!, t::Taylor1{T}, x::Vector{Taylor1{U}},
 
         # Equations of motion
         # stabilitymatrix!( eqsdiff!, t, view(xaux,1:dof), δx, dδx, jac )
-        for ind in 1:dof
+        for ind in eachindex(δx)
             @inbounds δx[ind] = xaux[ind] + _δv[ind]
         end
         eqsdiff!(taux, δx, dδx)

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,2 +1,2 @@
-TaylorSeries 0.7.1
+TaylorSeries 0.7.2
 Elliptic 0.4.1

--- a/test/bigfloats.jl
+++ b/test/bigfloats.jl
@@ -1,4 +1,4 @@
-using TaylorSeries, TaylorIntegration, Elliptic
+using TaylorIntegration, Elliptic
 using Base.Test
 
 const _order = 90

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -1,6 +1,6 @@
 # This file is part of the TaylorIntegration.jl package; MIT licensed
 
-using TaylorSeries, TaylorIntegration
+using TaylorIntegration
 using Base.Test
 
 const _order = 28

--- a/test/jettransport.jl
+++ b/test/jettransport.jl
@@ -1,6 +1,6 @@
 # This file is part of the TaylorIntegration.jl package; MIT licensed
 
-using TaylorSeries, TaylorIntegration, Elliptic
+using TaylorIntegration, Elliptic
 using Base.Test
 
 const _order = 28

--- a/test/lyapunov.jl
+++ b/test/lyapunov.jl
@@ -79,6 +79,11 @@ end
 
     @test lorenztr == -(σ+one(Float64)+β)
 
+    # Number of TaylorN variables should be equal to length of vector of initial conditions
+    xi = set_variables("δ", order=1, numvars=length(x0)-1)
+    @test_throws AssertionError liap_taylorinteg(lorenz!, x0, t0, tmax, 28, _abstol; maxsteps=2)
+
+    xi = set_variables("δ", order=1, numvars=length(x0))
     tv, xv, λv = liap_taylorinteg(lorenz!, x0, t0, tmax, 28, _abstol; maxsteps=2)
 
     @test size(tv) == (3,)

--- a/test/lyapunov.jl
+++ b/test/lyapunov.jl
@@ -14,15 +14,18 @@ const _abstol = 1.0E-20
         nothing
     end
     σ = 16.0; β = 4.0; ρ = 45.92 #Lorenz system parameters
-    t0 = 0.0 #the initial time
+    t0 = rand() #the initial time
     for i in 1:10
         x0 = 10rand(3) #the initial condition
+        x0T = Taylor1.(x0,_order)
         xi = set_variables("δ", order=1, numvars=length(x0))
-        δx = [ x0[1]+xi[1], x0[2]+xi[2], x0[3]+xi[3] ]
+        t_ = Taylor1([t0,1],_order)
+        δx = Array{TaylorN{Taylor1{eltype(x0)}}}(length(x0))
+        # @show δx
         dδx = similar(δx)
-        lorenzjac = Array{eltype(x0)}(3,3)
-        TaylorIntegration.stabilitymatrix!(lorenz!, t0, view(x0,:), δx, dδx, lorenzjac)
-        @test trace(lorenzjac) == -(σ+one(Float64)+β)
+        lorenzjac = Array{eltype(x0T)}(3,3)
+        TaylorIntegration.stabilitymatrix!(lorenz!, t_, view(x0T,:), δx, dδx, lorenzjac)
+        @test trace(lorenzjac.()) == -(σ+one(Float64)+β)
     end
 end
 

--- a/test/lyapunov.jl
+++ b/test/lyapunov.jl
@@ -1,6 +1,6 @@
 # This file is part of the TaylorIntegration.jl package; MIT licensed
 
-using TaylorSeries, TaylorIntegration
+using TaylorIntegration
 using Base.Test
 
 const _order = 28

--- a/test/lyapunov.jl
+++ b/test/lyapunov.jl
@@ -15,17 +15,16 @@ const _abstol = 1.0E-20
     end
     σ = 16.0; β = 4.0; ρ = 45.92 #Lorenz system parameters
     t0 = rand() #the initial time
+    xi = set_variables("δ", order=1, numvars=3)
+    t_ = Taylor1([t0,1],_order)
+    δx = Array{TaylorN{Taylor1{Float64}}}(3)
+    dδx = similar(δx)
+    lorenzjac = Array{Taylor1{Float64}}(3,3)
     for i in 1:10
         x0 = 10rand(3) #the initial condition
         x0T = Taylor1.(x0,_order)
-        xi = set_variables("δ", order=1, numvars=length(x0))
-        t_ = Taylor1([t0,1],_order)
-        δx = Array{TaylorN{Taylor1{eltype(x0)}}}(length(x0))
-        # @show δx
-        dδx = similar(δx)
-        lorenzjac = Array{eltype(x0T)}(3,3)
         TaylorIntegration.stabilitymatrix!(lorenz!, t_, view(x0T,:), δx, dδx, lorenzjac)
-        @test trace(lorenzjac.()) == -(σ+one(Float64)+β)
+        @test trace(constant_term.(lorenzjac)) == -(σ+one(Float64)+β)
     end
 end
 

--- a/test/lyapunov.jl
+++ b/test/lyapunov.jl
@@ -24,7 +24,7 @@ const _abstol = 1.0E-20
         x0 = 10rand(3) #the initial condition
         x0T = Taylor1.(x0,_order)
         TaylorIntegration.stabilitymatrix!(lorenz!, t_, view(x0T,:), δx, dδx, lorenzjac)
-        @test trace(constant_term.(lorenzjac)) == -(σ+one(Float64)+β)
+        @test trace(lorenzjac.()) == -(σ+one(Float64)+β)
     end
 end
 

--- a/test/many_ode.jl
+++ b/test/many_ode.jl
@@ -1,6 +1,6 @@
 # This file is part of the TaylorIntegration.jl package; MIT licensed
 
-using TaylorSeries, TaylorIntegration
+using TaylorIntegration
 using Base.Test
 
 const _order = 28

--- a/test/one_ode.jl
+++ b/test/one_ode.jl
@@ -1,6 +1,6 @@
 # This file is part of the TaylorIntegration.jl package; MIT licensed
 
-using TaylorSeries, TaylorIntegration
+using TaylorIntegration
 using Base.Test
 
 const _order = 28

--- a/test/rootfinding.jl
+++ b/test/rootfinding.jl
@@ -1,6 +1,6 @@
 # This file is part of the TaylorIntegration.jl package; MIT licensed
 
-using TaylorSeries, TaylorIntegration
+using TaylorIntegration
 using Base.Test
 
 const _order = 28


### PR DESCRIPTION
This PR adds non-breaking changes to internal Lyapunov spectrum code, and should improve performance a bit. In particular, `stabilitymatrix!` might not be necessary anymore. Tests are passing in julia 0.6.

Also, this PR `@reexport`s TaylorSeries (this change is also included also in #31, but it is really helpful! so I thought it'd be nice to have this already in current master, while #31 is merged)

cc: @lbenet 