### PR TITLE
Include version upper bounds for requirements

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.6
-TaylorSeries 0.7.2
+julia 0.6 0.7
+TaylorSeries 0.7.2 0.8.0
 Reexport
 DiffEqBase 3.8.0


### PR DESCRIPTION
This PR is to prepare the transition to support Julia 0.7 and Julia 1.0; I suggest to merge this (and other commits), release patch a version, which would be the last to support Julia 0.6.