### PR TITLE
Further performance improvement of `lyap_taylorinteg`: `lyap_jetcoeffs!` strikes back!

### DIFF
--- a/src/lyapunovspectrum.jl
+++ b/src/lyapunovspectrum.jl
@@ -92,9 +92,9 @@ end
 
 Similar to [`jetcoeffs!`](@ref) for the calculation of the Lyapunov spectrum.
 Returns an updated `x` using the recursion relation of the derivatives obtained
-from the 1st-order variational equations \$\\dot{\\xi}=dx/dt=J \\cdot \\xi\$, where
+from the 1st-order variational equations \$\\dot{\\xi}=J \\cdot \\xi\$, where
 \$J\$ is the Jacobian matrix, i.e., the linearization of the equations of motion.
-`jac` is Taylor expansion of \$J\$ wrt the independent variable, around the
+`jac` is the Taylor expansion of \$J\$ wrt the independent variable, around the
 current initial condition.
 """
 function lyap_jetcoeffs!(t::Taylor1{T}, x::AbstractVector{Taylor1{S}},

--- a/src/lyapunovspectrum.jl
+++ b/src/lyapunovspectrum.jl
@@ -1,26 +1,6 @@
 # This file is part of the TaylorIntegration.jl package; MIT licensed
 
 """
-    stabilitymatrix!(eqsdiff!, t, x, δx, dδx, jac)
-
-Updates the matrix `jac::Matrix{Taylor1{U}}` (linearized equations of motion)
-computed from the equations of motion (`eqsdiff!`), at time `t` at `x`; `x` is
-of type `Vector{Taylor1{U}}`, where `U<:Number`. `δx` and `dδx` are two
-auxiliary arrays of type `Vector{TaylorN{Taylor1{U}}}` to avoid allocations.
-
-"""
-function stabilitymatrix!(eqsdiff!, t::Taylor1{T},
-        x::SubArray{Taylor1{U},1}, δx::Array{TaylorN{Taylor1{U}},1},
-        dδx::Array{TaylorN{Taylor1{U}},1}, jac::Array{Taylor1{U},2}) where {T<:Real, U<:Number}
-    for ind in eachindex(x)
-        @inbounds δx[ind] = x[ind] + TaylorN(Taylor1{U},ind,order=1)
-    end
-    eqsdiff!(t, δx, dδx)
-    jacobian!( jac, dδx )
-    nothing
-end
-
-"""
     stabilitymatrix!(eqsdiff!, t, x, δx, dδx, jac, _δv[, jacobianfunc!])
 
 Updates the matrix `jac::Matrix{Taylor1{U}}` (linearized equations of motion)

--- a/src/lyapunovspectrum.jl
+++ b/src/lyapunovspectrum.jl
@@ -166,8 +166,11 @@ function lyap_taylorstep!(f!, t::Taylor1{T}, x::Vector{Taylor1{U}},
     # Dimensions of phase-space: dof
     nx = length(x)
     dof = length(δx)
+    # Compute the Taylor coefficients associated to trajectory
     jetcoeffs!(f!, t, view(x, 1:dof), view(dx, 1:dof), view(xaux, 1:dof))
+    # Compute stability matrix
     stabilitymatrix!(f!, t, x, δx, dδx, jac, _δv, jacobianfunc!)
+    # Compute the Taylor coefficients associated to variational equations
     lyap_jetcoeffs!(t, view(x, dof+1:nx), view(dx, dof+1:nx), jac)
     # Compute the step-size of the integration using `abstol`
     δt = stepsize(view(x, 1:dof), abstol)

--- a/src/lyapunovspectrum.jl
+++ b/src/lyapunovspectrum.jl
@@ -104,7 +104,8 @@ Updates *only* the elements of `x` which correspond to the solution of the 1st-o
 variational equations \$\\dot{\\xi}=J \\cdot \\xi\$, where \$J\$ is the Jacobian
 matrix, i.e., the linearization of the equations of motion. `jac` is the Taylor
 expansion of \$J\$ wrt the independent variable, around the current initial
-condition. Use of this method assumes that `jac` has been computed previously.
+condition. Calling this method assumes that `jac` has been computed previously
+using [`stabilitymatrix!`](@ref).
 
 """
 function lyap_jetcoeffs!(t::Taylor1{T}, x::AbstractVector{Taylor1{S}},

--- a/src/lyapunovspectrum.jl
+++ b/src/lyapunovspectrum.jl
@@ -86,20 +86,17 @@ function modifiedGS!(A, Q, R, aⱼ, qᵢ, vⱼ)
     return nothing
 end
 
-function variational_eqs!(t::Taylor1{T}, x::Vector{Taylor1{U}},
-        dx::Vector{Taylor1{U}}, jac::Array{Taylor1{U},2}, jacobianfunc! =Nothing) where {T<:Real, U<:Number}
-    # Dimensions of phase-space: dof
-    nx = length(x)
-    dof = size(jac, 1)
-    if jacobianfunc! != Nothing
-        # Stability matrix
-        jacobianfunc!(jac, t, x)
-    end
-    @inbounds dx[dof+1:nx] = jac * reshape( x[dof+1:nx], (dof,dof) )
-    return nothing
-end
-
 # `@taylorize`'d version of TaylorIntegration.jetcoeffs! for 1st order variational equations
+"""
+    lyap_jetcoeffs!(t, x, dx, jac)
+
+Similar to [`jetcoeffs!`](@ref) for the calculation of the Lyapunov spectrum.
+Returns an updated `x` using the recursion relation of the derivatives obtained
+from the 1st-order variational equations \$\\dot{\\xi}=dx/dt=J \\cdot \\xi\$, where
+\$J\$ is the Jacobian matrix, i.e., the linearization of the equations of motion.
+`jac` is Taylor expansion of \$J\$ wrt the independent variable, around the
+current initial condition.
+"""
 function lyap_jetcoeffs!(t::Taylor1{T}, x::AbstractVector{Taylor1{S}},
         dx::AbstractVector{Taylor1{S}}, jac::Matrix{Taylor1{S}}) where {T <: Real, S <: Number}
     order = t.order
@@ -169,8 +166,6 @@ function lyap_taylorstep!(f!, t::Taylor1{T}, x::Vector{Taylor1{U}},
         f!(t, δx, dδx)
         # Stability matrix
         jacobian!(jac, dδx)
-    # end
-    # jetcoeffs!((t, x, dx)->variational_eqs!(t, x, dx, jac, jacobianfunc!), t, x, dx, xaux)
     else
         # Stability matrix
         jacobianfunc!(jac, t, x)

--- a/src/lyapunovspectrum.jl
+++ b/src/lyapunovspectrum.jl
@@ -186,7 +186,7 @@ function lyap_taylorstep!(f!, t::Taylor1{T}, x::Vector{Taylor1{U}},
     nx = length(x)
     dof = length(δx)
     jetcoeffs!(f!, t, view(x, 1:dof), view(dx, 1:dof), view(xaux, 1:dof))
-    stabilitymatrix!(eqsdiff!, t, x,δx, dδx, jac, _δv, jacobianfunc!)
+    stabilitymatrix!(f!, t, x,δx, dδx, jac, _δv, jacobianfunc!)
     lyap_jetcoeffs!(t, view(x, dof+1:nx), view(dx, dof+1:nx), jac)
     # Compute the step-size of the integration using `abstol`
     δt = stepsize(view(x, 1:dof), abstol)

--- a/src/lyapunovspectrum.jl
+++ b/src/lyapunovspectrum.jl
@@ -117,9 +117,9 @@ function lyap_jetcoeffs!(t::Taylor1{T}, x::AbstractVector{Taylor1{S}},
     nlyaps = size(jac, 1)
     inds = axes(jac, 1)
     # 0-th order evaluation of variational equations
+    dx .= zero(x[1])
     for j in inds
         for i in inds
-            dx[nlyaps * (j - 1) + i] = Taylor1(zero(constant_term(x[1])), order)
             for k in inds
                 varsaux[k, i, j] = Taylor1(constant_term(jac[i, k]) * constant_term(x[nlyaps * (j - 1) + k]), order)
                 dx[nlyaps * (j - 1) + i] = Taylor1(constant_term(dx[nlyaps * (j - 1) + i]) + constant_term(varsaux[k, i, j]), order)

--- a/src/lyapunovspectrum.jl
+++ b/src/lyapunovspectrum.jl
@@ -211,13 +211,13 @@ function lyap_taylorinteg(f!, q0::Array{U,1}, t0::T, tmax::T,
 
     # Initial conditions
     @inbounds tv[1] = t0
-    for ind in eachindex(q0)
-        @inbounds xv[ind,1] = q0[ind]
-        @inbounds λ[ind,1] = zero(U)
-        @inbounds λtsum[ind] = zero(U)
+    @inbounds for ind in eachindex(q0)
+        xv[ind,1] = q0[ind]
+        λ[ind,1] = zero(U)
+        λtsum[ind] = zero(U)
     end
     x0 = vcat(q0, reshape(jt, dof*dof))
-    nx0 = dof*(dof+1)
+    nx0 = length(x0)
     t00 = t0
 
     # Initialize the vector of Taylor1 expansions

--- a/src/lyapunovspectrum.jl
+++ b/src/lyapunovspectrum.jl
@@ -86,16 +86,15 @@ function modifiedGS!(A, Q, R, aⱼ, qᵢ, vⱼ)
     return nothing
 end
 
-# `@taylorize`'d version of TaylorIntegration.jetcoeffs! for 1st order variational equations
 """
     lyap_jetcoeffs!(t, x, dx, jac)
 
 Similar to [`jetcoeffs!`](@ref) for the calculation of the Lyapunov spectrum.
-Returns an updated `x` using the recursion relation of the derivatives obtained
-from the 1st-order variational equations \$\\dot{\\xi}=J \\cdot \\xi\$, where
-\$J\$ is the Jacobian matrix, i.e., the linearization of the equations of motion.
-`jac` is the Taylor expansion of \$J\$ wrt the independent variable, around the
-current initial condition.
+Updates *only* the elements of `x` which correspond to the solution of the 1st-order
+variational equations \$\\dot{\\xi}=J \\cdot \\xi\$, where \$J\$ is the Jacobian
+matrix, i.e., the linearization of the equations of motion. `jac` is the Taylor
+expansion of \$J\$ wrt the independent variable, around the current initial
+condition. Use of this method assumes that `jac` has been computed previously.
 """
 function lyap_jetcoeffs!(t::Taylor1{T}, x::AbstractVector{Taylor1{S}},
         dx::AbstractVector{Taylor1{S}}, jac::Matrix{Taylor1{S}}) where {T <: Real, S <: Number}

--- a/src/lyapunovspectrum.jl
+++ b/src/lyapunovspectrum.jl
@@ -166,7 +166,7 @@ function lyap_taylorstep!(f!, t::Taylor1{T}, x::Vector{Taylor1{U}},
     nx = length(x)
     dof = length(δx)
     jetcoeffs!(f!, t, view(x, 1:dof), view(dx, 1:dof), view(xaux, 1:dof))
-    stabilitymatrix!(f!, t, x,δx, dδx, jac, _δv, jacobianfunc!)
+    stabilitymatrix!(f!, t, x, δx, dδx, jac, _δv, jacobianfunc!)
     lyap_jetcoeffs!(t, view(x, dof+1:nx), view(dx, dof+1:nx), jac)
     # Compute the step-size of the integration using `abstol`
     δt = stepsize(view(x, 1:dof), abstol)

--- a/src/lyapunovspectrum.jl
+++ b/src/lyapunovspectrum.jl
@@ -115,11 +115,12 @@ function lyap_jetcoeffs!(t::Taylor1{T}, x::AbstractVector{Taylor1{S}},
     order = t.order
     # number of Lyapunov exponents
     nlyaps = size(jac, 1)
+    inds = axes(jac, 1)
     # 0-th order evaluation of variational equations
-    for j = 1:nlyaps
-        for i = 1:nlyaps
+    for j in inds
+        for i in inds
             dx[nlyaps * (j - 1) + i] = Taylor1(zero(constant_term(x[1])), order)
-            for k = 1:nlyaps
+            for k in inds
                 varsaux[k, i, j] = Taylor1(constant_term(jac[i, k]) * constant_term(x[nlyaps * (j - 1) + k]), order)
                 dx[nlyaps * (j - 1) + i] = Taylor1(constant_term(dx[nlyaps * (j - 1) + i]) + constant_term(varsaux[k, i, j]), order)
             end
@@ -132,10 +133,10 @@ function lyap_jetcoeffs!(t::Taylor1{T}, x::AbstractVector{Taylor1{S}},
     # Compute Taylor coefficients of variational equations up to order `order`
     for ord = 1:order - 1
         ordnext = ord + 1
-        for j = 1:nlyaps
-            for i = 1:nlyaps
+        for j in inds
+            for i in inds
                 TaylorSeries.zero!(dx[nlyaps * (j - 1) + i], x[1], ord)
-                for k = 1:nlyaps
+                for k in inds
                     TaylorSeries.mul!(varsaux[k, i, j], jac[i, k], x[nlyaps * (j - 1) + k], ord)
                     TaylorSeries.add!(dx[nlyaps * (j - 1) + i], dx[nlyaps * (j - 1) + i], varsaux[k, i, j], ord)
                 end

--- a/src/lyapunovspectrum.jl
+++ b/src/lyapunovspectrum.jl
@@ -113,21 +113,21 @@ function lyap_jetcoeffs!(t::Taylor1{T}, x::AbstractVector{Taylor1{S}},
         dx::AbstractVector{Taylor1{S}}, jac::Matrix{Taylor1{S}},
         varsaux::Array{Taylor1{S},3}) where {T <: Real, S <: Number}
     order = t.order
-    # `dofrange` behaves like 1:dof, where `dof = size(jac, 1)`. Used to initialize `b` and `I`
+    # `dofrange` behaves like 1:dof, where `dof = size(jac, 1)`. Used to initialize `b` and `li`
     dofrange = axes(jac, 1)
     # The `view` below allows us to obtain CartesianIndices from `varsaux` when calling `eachindex(b)`
     # `varsaux` is an array with size n×n×n
     b = view(varsaux, dofrange, dofrange, dofrange)
-    # We use `I` to map between cartesian and linear indices
-    I = LinearIndices((dofrange, dofrange))
+    # We use `li` to map between cartesian and linear indices
+    li = LinearIndices((dofrange, dofrange))
 
     # 0-th order evaluation of variational equations `dx = jac * x`
     # Initialize LHS of variational equations at zero
     dx .= zero(x[1])
     # Compute 0-th Taylor coefficients of matrix product `jac * x` and save into `dx`
     for i in eachindex(b)
-        varsaux[i] = Taylor1(constant_term(jac[ i[1], i[3] ]) * constant_term(x[ I[i[3], i[2]] ]), order)
-        lin_indx = I[ i[1], i[2]] # map from cartesian to linear index
+        varsaux[i] = Taylor1(constant_term(jac[ i[1], i[3] ]) * constant_term(x[ li[i[3], i[2]] ]), order)
+        lin_indx = li[ i[1], i[2]] # map from cartesian to linear index
         dx[lin_indx] = Taylor1(constant_term(dx[lin_indx]) + constant_term(varsaux[i]), order)
     end
     # Recursion relations, 0-th order
@@ -140,8 +140,8 @@ function lyap_jetcoeffs!(t::Taylor1{T}, x::AbstractVector{Taylor1{S}},
         ordnext = ord + 1
         # Compute `ord`-th Taylor coefficients of matrix product `jac * x` and save into `dx`
         for i in eachindex(b)
-            TaylorSeries.mul!(varsaux[i], jac[ i[1], i[3] ], x[ I[i[3], i[2]] ], ord)
-            lin_indx = I[ i[1], i[2]] # map from cartesian to linear index
+            TaylorSeries.mul!(varsaux[i], jac[ i[1], i[3] ], x[ li[i[3], i[2]] ], ord)
+            lin_indx = li[ i[1], i[2]] # map from cartesian to linear index
             TaylorSeries.add!(dx[lin_indx], dx[lin_indx], varsaux[i], ord)
         end
         # Recursion relations, `ord`-th order

--- a/src/lyapunovspectrum.jl
+++ b/src/lyapunovspectrum.jl
@@ -209,15 +209,6 @@ function lyap_taylorinteg(f!, q0::Array{U,1}, t0::T, tmax::T,
     jt = Matrix{U}(I, dof, dof)
     _δv = Array{TaylorN{Taylor1{U}}}(undef, dof)
 
-    # Check only if user does not provide Jacobian
-    if jacobianfunc! == Nothing
-        @assert get_numvars() == dof "`length(q0)` must be equal to number of variables set by `TaylorN`"
-    end
-
-    for ind in eachindex(q0)
-        _δv[ind] = TaylorN(Taylor1{U},ind,order=1)
-    end
-
     # Initial conditions
     @inbounds tv[1] = t0
     for ind in eachindex(q0)
@@ -234,6 +225,14 @@ function lyap_taylorinteg(f!, q0::Array{U,1}, t0::T, tmax::T,
     x = Array{Taylor1{U}}(undef, nx0)
     x .= Taylor1.( x0, order )
     @inbounds t[0] = t0
+
+    # If user does not provide Jacobian, check number of TaylorN variables and initialize _δv
+    if jacobianfunc! == Nothing
+        @assert get_numvars() == dof "`length(q0)` must be equal to number of variables set by `TaylorN`"
+        for ind in eachindex(q0)
+            _δv[ind] = one(x[1])*TaylorN(Taylor1{U}, ind, order=1)
+        end
+    end
 
     #Allocate auxiliary arrays
     dx = Array{Taylor1{U}}(undef, nx0)

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,2 +1,2 @@
-TaylorSeries 0.7.4
-Elliptic 0.5.0
+TaylorSeries v0.8.0
+Elliptic v0.5.0

--- a/test/lyapunov.jl
+++ b/test/lyapunov.jl
@@ -42,7 +42,7 @@ end
     for i in 1:10
         x0 = 10rand(3) #the initial condition
         x0T = Taylor1.(x0,_order)
-        TaylorIntegration.stabilitymatrix!(lorenz!, t_, view(x0T,:), δx, dδx, lorenzjac, _δv)
+        TaylorIntegration.stabilitymatrix!(lorenz!, t_, x0T, δx, dδx, lorenzjac, _δv)
         @test tr(lorenzjac.()) == -(1+σ+β)
     end
 end

--- a/test/lyapunov.jl
+++ b/test/lyapunov.jl
@@ -39,10 +39,18 @@ end
     for ind in 1:3
         _δv[ind] = one(t_)*TaylorN(Taylor1{Float64}, ind, order=1)
     end
+    # test computation of jac via autodiff
     for i in 1:10
         x0 = 10rand(3) #the initial condition
         x0T = Taylor1.(x0,_order)
         TaylorIntegration.stabilitymatrix!(lorenz!, t_, x0T, δx, dδx, lorenzjac, _δv)
+        @test tr(lorenzjac.()) == -(1+σ+β)
+    end
+    #test computation of jac via user-provided Jacobian function
+    for i in 1:10
+        x0 = 10rand(3) #the initial condition
+        x0T = Taylor1.(x0,_order)
+        TaylorIntegration.stabilitymatrix!(lorenz!, t_, x0T, δx, dδx, lorenzjac, _δv, lorenz_jac!)
         @test tr(lorenzjac.()) == -(1+σ+β)
     end
 end

--- a/test/lyapunov.jl
+++ b/test/lyapunov.jl
@@ -35,10 +35,14 @@ end
     δx = Array{TaylorN{Taylor1{Float64}}}(undef, 3)
     dδx = similar(δx)
     lorenzjac = Array{Taylor1{Float64}}(undef, 3, 3)
+    _δv = Array{TaylorN{Taylor1{Float64}}}(undef, 3)
+    for ind in 1:3
+        _δv[ind] = one(t_)*TaylorN(Taylor1{Float64}, ind, order=1)
+    end
     for i in 1:10
         x0 = 10rand(3) #the initial condition
         x0T = Taylor1.(x0,_order)
-        TaylorIntegration.stabilitymatrix!(lorenz!, t_, view(x0T,:), δx, dδx, lorenzjac)
+        TaylorIntegration.stabilitymatrix!(lorenz!, t_, view(x0T,:), δx, dδx, lorenzjac, _δv)
         @test tr(lorenzjac.()) == -(1+σ+β)
     end
 end
@@ -212,5 +216,5 @@ end
     # Check integration consistency (orbit should not depend on variational eqs)
     x_ = taylorinteg(lorenz!, q0, collect(t0:1.0:tmax), _order, _abstol; maxsteps=2000)
     @test x_ == xw2
-    
+
 end


### PR DESCRIPTION
This PR is aimed towards improving performance of `lyap_taylorinteg`. The changes introduced by this PR are mainly the following:

- Compute the Jacobian `jac`, either by automatic differentiation or by the Jacobian function provided by the user, in a separate function `stabilitymatrix!`.
- Bring back `lyap_jetcoeffs!`, which now computes *only* the jet of coefficients in the vector of dependent variables `x` associated  to the variational equations. Another difference is that instead of passing the differential equations `eqsdiff!` as an argument to this function, only the Jacobian `jac` is passed. The implementation of `lyap_jetcoeffs!` was actually obtained meta-programatically using the `@taylorize` macro (see #31 ), with some manual tweaks.
- Tests and docstrings have been updated accordingly.