### PR TITLE
Add documentation badge (latest) in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Coverage:
 [coveralls-img]: https://img.shields.io/travis/PerezHz/TaylorIntegration.jl/master.svg?label=coveralls
 [codecov-img]: https://img.shields.io/travis/PerezHz/TaylorIntegration.jl/master.svg?label=codecov
 
+Documentation:
+[![](https://img.shields.io/badge/docs-latest-blue.svg)](https://PerezHz.github.io/TaylorIntegration.jl/latest)
 
 ODE integration using Taylor's method in [Julia](http://julialang.org).
 


### PR DESCRIPTION
travis has deployed the documentation, therefore the TaylorIntegration.jl docs are now available online. This PR simply adds the "latest" documentation badge to README.md.

Afaict, there is only one minor issue: the gif's generated in the root-finding examples are not being displayed correctly. The JuliaPlots organization has solved the issue of including gifs in the Plots.jl documentation (PlotDocs.jl) by adding the gifs to the PlotReferenceImages.jl GitHub repo and referencing those. I propose to handle this issue in a separate PR.