### PR TITLE
Fix Lyapunov spectrum integrator with time ranges/vectors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ os:
 julia:
   - 0.7
   - 1.0
+  - 1.1
   - nightly
 
 notifications:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,7 @@ environment:
   matrix:
   - julia_version: 0.7
   - julia_version: 1.0
+  - julia_version: 1.1
   - julia_version: nightly
 
 platform:

--- a/src/lyapunovspectrum.jl
+++ b/src/lyapunovspectrum.jl
@@ -310,7 +310,8 @@ function lyap_taylorinteg(f!, q0::Array{U,1}, trange::AbstractVector{T},
     dof = length(q0)
     xv = Array{U}(undef, dof, nn)
     fill!(xv, U(NaN))
-    λ = Array{U}(undef, dof, maxsteps+1)
+    λ = Array{U}(undef, dof, nn)
+    # fill!(λ, U(NaN))
     λtsum = similar(q0)
     jt = Matrix{U}(I, dof, dof)
     _δv = Array{TaylorN{Taylor1{U}}}(undef, dof)
@@ -371,31 +372,51 @@ function lyap_taylorinteg(f!, q0::Array{U,1}, trange::AbstractVector{T},
     nsteps = 1
     while t0 < tmax
         δt = lyap_taylorstep!(f!, t, x, dx, xaux, δx, dδx, jac, t0, tmax, x0, order, abstol, _δv, varsaux, parse_eqs, jacobianfunc!)
+        # for ind in eachindex(jt)
+        #     @inbounds jt[ind] = x0[dof+ind]
+        # end
+        # modifiedGS!( jt, QH, RH, aⱼ, qᵢ, vⱼ )
+        tnext = t0+δt
+        # # Evaluate solution at times within convergence radius
+        while t1 <= tnext
+            evaluate!(x[1:dof], t1-t0, q1)
+            @inbounds xv[:,iter] .= q1
+
+            for ind in eachindex(jt)
+                @inbounds jt[ind] = evaluate(x[dof+ind], δt)
+            end
+                modifiedGS!( jt, QH, RH, aⱼ, qᵢ, vⱼ )
+            tspan = t1-t00
+            @inbounds for ind in eachindex(q0)
+                # xv[ind,nsteps] = x0[ind]
+                # λtsum[ind] += log(RH[ind,ind])
+                λ[ind,iter] = (λtsum[ind]+log(RH[ind,ind]))/tspan
+            end
+
+            iter += 1
+            @inbounds t1 = trange[iter]
+            nsteps = 0
+        end
+
         for ind in eachindex(jt)
             @inbounds jt[ind] = x0[dof+ind]
         end
         modifiedGS!( jt, QH, RH, aⱼ, qᵢ, vⱼ )
-        tnext = t0+δt
-        # Evaluate solution at times within convergence radius
-        while t1 < tnext
-            evaluate!(x[1:dof], t1-t0, q1)
-            @inbounds xv[:,iter] .= q1
-            iter += 1
-            @inbounds t1 = trange[iter]
-        end
-        if δt == tmax-t0
-            @inbounds xv[:,iter] .= x0[1:dof]
-            break
-        end
+
+
+        # if δt == tmax-t0
+        #     @inbounds xv[:,iter] .= x0[1:dof]
+        #     break
+        # end
         t0 = tnext
         @inbounds t[0] = t0
-        tspan = t0-t00
+        # tspan = t0-t00
         nsteps += 1
         # @inbounds tv[nsteps] = t0
         @inbounds for ind in eachindex(q0)
             # xv[ind,nsteps] = x0[ind]
             λtsum[ind] += log(RH[ind,ind])
-            λ[ind,nsteps] = λtsum[ind]/tspan
+            # λ[ind,nsteps] = λtsum[ind]/tspan
         end
         for ind in eachindex(QH)
             @inbounds x0[dof+ind] = QH[ind]
@@ -409,5 +430,5 @@ function lyap_taylorinteg(f!, q0::Array{U,1}, trange::AbstractVector{T},
         end
     end
 
-    return transpose(xv),  view(transpose(λ),1:nsteps,:)
+    return transpose(xv), transpose(λ)
 end

--- a/test/lyapunov.jl
+++ b/test/lyapunov.jl
@@ -206,9 +206,13 @@ end
     @time xw, λw = lyap_taylorinteg(lorenz!, q0, trange, _order, _abstol; maxsteps=2000)
     @test xw[1,:] == q0
     @test size(xw) == (length(trange), length(q0))
-    # @test size(λw) == (length(trange), length(q0))
+    @test size(λw) == (length(trange), length(q0))
     @test isapprox(sum(λw[1,:]), lorenztr) == false
     @test isapprox(sum(λw[end,:]), lorenztr)
+    tz, xz, λz = lyap_taylorinteg(lorenz!, q0, trange[1], trange[end], _order, _abstol; maxsteps=2000)
+    @test λw[end,:] == λz[end,:]
+    @test xw[end,:] == xz[end,:]
+    @test tz[end] == trange[end]
     mytol = 1e-4
     @test isapprox(λw[end,1], 1.47167, rtol=mytol, atol=mytol)
     @test isapprox(λw[end,2], -0.00831, rtol=mytol, atol=mytol)
@@ -216,6 +220,10 @@ end
     @time xw_, λw_ = lyap_taylorinteg(lorenz!, q0, trange, _order, _abstol, lorenz_jac!; maxsteps=2000)
     @test xw == xw_
     @test λw == λw_
+    tz_, xz_, λz_ = lyap_taylorinteg(lorenz!, q0, trange[1], trange[end], _order, _abstol, lorenz_jac!; maxsteps=2000)
+    @test λw_[end,:] == λz_[end,:]
+    @test xw_[end,:] == xz_[end,:]
+    @test tz_[end] == trange[end]
 
     @time xw2, λw2 = lyap_taylorinteg(lorenz!, q0, vec(trange), _order, _abstol; maxsteps=2000)
     @test xw2 == xw
@@ -224,6 +232,10 @@ end
     @test size(xw) == (length(trange), length(q0))
     @test isapprox(sum(λw2[1,:]), lorenztr) == false
     @test isapprox(sum(λw2[end,:]), lorenztr)
+    tz2, xz2, λz2 = lyap_taylorinteg(lorenz!, q0, trange[1], trange[end], _order, _abstol; maxsteps=2000)
+    @test λw2[end,:] == λz2[end,:]
+    @test xw2[end,:] == xz2[end,:]
+    @test tz2[end] == trange[end]
     mytol = 1e-4
     @test isapprox(λw2[end,1], 1.47167, rtol=mytol, atol=mytol)
     @test isapprox(λw2[end,2], -0.00831, rtol=mytol, atol=mytol)
@@ -231,6 +243,10 @@ end
     @time xw2_, λw2_ = lyap_taylorinteg(lorenz!, q0, vec(trange), _order, _abstol, lorenz_jac!; maxsteps=2000)
     @test xw2 == xw2_
     @test λw2 == λw2_
+    tz2_, xz2_, λz2_ = lyap_taylorinteg(lorenz!, q0, trange[1], trange[end], _order, _abstol, lorenz_jac!; maxsteps=2000)
+    @test λw2_[end,:] == λz2_[end,:]
+    @test xw2_[end,:] == xz2_[end,:]
+    @test tz2_[end] == trange[end]
 
     # Check integration consistency (orbit should not depend on variational eqs)
     x_ = taylorinteg(lorenz!, q0, vec(trange), _order, _abstol; maxsteps=2000)

--- a/test/lyapunov.jl
+++ b/test/lyapunov.jl
@@ -198,9 +198,9 @@ end
     @test isapprox(sum(λw[1,:]), lorenztr) == false
     @test isapprox(sum(λw[end,:]), lorenztr)
     mytol = 1e-4
-    @test isapprox(λw[end,1], 1.46486, rtol=mytol, atol=mytol)
-    @test isapprox(λw[end,2], -0.00471, rtol=mytol, atol=mytol)
-    @test isapprox(λw[end,3], -22.46015, rtol=mytol, atol=mytol)
+    @show isapprox(λw[end,1], 1.46486, rtol=mytol, atol=mytol)
+    @show isapprox(λw[end,2], -0.00471, rtol=mytol, atol=mytol)
+    @show isapprox(λw[end,3], -22.46015, rtol=mytol, atol=mytol)
     @time xw_, λw_ = lyap_taylorinteg(lorenz!, q0, trange, _order, _abstol, lorenz_jac!; maxsteps=2000)
     @test xw == xw_
     @test λw == λw_
@@ -213,9 +213,9 @@ end
     @test isapprox(sum(λw2[1,:]), lorenztr) == false
     @test isapprox(sum(λw2[end,:]), lorenztr)
     mytol = 1e-4
-    @test isapprox(λw2[end,1], 1.46486, rtol=mytol, atol=mytol)
-    @test isapprox(λw2[end,2], -0.00471, rtol=mytol, atol=mytol)
-    @test isapprox(λw2[end,3], -22.46015, rtol=mytol, atol=mytol)
+    @show isapprox(λw2[end,1], 1.46486, rtol=mytol, atol=mytol)
+    @show isapprox(λw2[end,2], -0.00471, rtol=mytol, atol=mytol)
+    @show isapprox(λw2[end,3], -22.46015, rtol=mytol, atol=mytol)
     @time xw2_, λw2_ = lyap_taylorinteg(lorenz!, q0, vec(trange), _order, _abstol, lorenz_jac!; maxsteps=2000)
     @test xw2 == xw2_
     @test λw2 == λw2_

--- a/test/lyapunov.jl
+++ b/test/lyapunov.jl
@@ -177,19 +177,31 @@ end
     xw, λw = lyap_taylorinteg(lorenz!, q0, trange, _order, _abstol; maxsteps=5)
     @test xw[1,:] == q0
     @test size(xw) == (length(trange), 3)
-    @test size(λw) == (6, 3) # 6 = maxsteps+1
-    @test prod(isnan.(xw[2:end,:]))
+    @test λw[1,:] == zeros(3)
+    @test size(λw) == size(xw)
+    @test all(isnan.(xw[2:end,:]))
+    @test all(isnan.(λw[2:end,:]))
     xw2, λw2 = lyap_taylorinteg(lorenz!, q0, vec(trange), _order, _abstol; maxsteps=5)
     @test xw[1, :] == xw2[1, :]
-    @test λw == λw2
+    @test all(isnan.(xw2[2:end,:]))
+    @test λw2[1, :] == zeros(3)
+    @test all(isnan.(λw2[2:end,:]))
+    @test size(xw2) == (length(trange), 3)
+    @test size(λw2) == size(xw2)
     xw_, λw_ = lyap_taylorinteg(lorenz!, q0, trange, _order, _abstol, lorenz_jac!; maxsteps=5)
-    @test xw[1,:] == q0
-    @test size(xw) == (length(trange), 3)
-    @test size(λw) == (6, 3) # 6 = maxsteps+1
-    @test prod(isnan.(xw[2:end,:]))
+    @test xw_[1,:] == q0
+    @test all(isnan.(xw_[2:end,:]))
+    @test size(xw_) == (length(trange), 3)
+    @test size(λw_) == size(xw_)
+    @test λw_[1, :] == zeros(3)
+    @test all(isnan.(λw_[2:end,:]))
     xw2_, λw2_ = lyap_taylorinteg(lorenz!, q0, vec(trange), _order, _abstol, lorenz_jac!; maxsteps=5)
     @test xw_[1, :] == xw2_[1, :]
-    @test λw_ == λw2_
+    @test all(isnan.(xw2_[2:end,:]))
+    @test λw2_[1, :] == zeros(3)
+    @test all(isnan.(λw2_[2:end,:]))
+    @test size(xw2_) == (length(trange), 3)
+    @test size(λw2_) == size(xw2_)
 
     @time xw, λw = lyap_taylorinteg(lorenz!, q0, trange, _order, _abstol; maxsteps=2000)
     @test xw[1,:] == q0
@@ -198,9 +210,9 @@ end
     @test isapprox(sum(λw[1,:]), lorenztr) == false
     @test isapprox(sum(λw[end,:]), lorenztr)
     mytol = 1e-4
-    @show isapprox(λw[end,1], 1.46486, rtol=mytol, atol=mytol)
-    @show isapprox(λw[end,2], -0.00471, rtol=mytol, atol=mytol)
-    @show isapprox(λw[end,3], -22.46015, rtol=mytol, atol=mytol)
+    @test isapprox(λw[end,1], 1.47167, rtol=mytol, atol=mytol)
+    @test isapprox(λw[end,2], -0.00831, rtol=mytol, atol=mytol)
+    @test isapprox(λw[end,3], -22.46336, rtol=mytol, atol=mytol)
     @time xw_, λw_ = lyap_taylorinteg(lorenz!, q0, trange, _order, _abstol, lorenz_jac!; maxsteps=2000)
     @test xw == xw_
     @test λw == λw_
@@ -213,9 +225,9 @@ end
     @test isapprox(sum(λw2[1,:]), lorenztr) == false
     @test isapprox(sum(λw2[end,:]), lorenztr)
     mytol = 1e-4
-    @show isapprox(λw2[end,1], 1.46486, rtol=mytol, atol=mytol)
-    @show isapprox(λw2[end,2], -0.00471, rtol=mytol, atol=mytol)
-    @show isapprox(λw2[end,3], -22.46015, rtol=mytol, atol=mytol)
+    @test isapprox(λw2[end,1], 1.47167, rtol=mytol, atol=mytol)
+    @test isapprox(λw2[end,2], -0.00831, rtol=mytol, atol=mytol)
+    @test isapprox(λw2[end,3], -22.46336, rtol=mytol, atol=mytol)
     @time xw2_, λw2_ = lyap_taylorinteg(lorenz!, q0, vec(trange), _order, _abstol, lorenz_jac!; maxsteps=2000)
     @test xw2 == xw2_
     @test λw2 == λw2_


### PR DESCRIPTION
After merging #62 it was noted that, while orbits and Lyapunov spectra computed with `lyap_taylorinteg` are now independent of the time range/vector provided by the user, the Lyapunov exponents were not being evaluated at each point specified by the time range/vector. This PR fixes this issue.