### PR TITLE
Conditionally require DiffEqBase

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -3,3 +3,4 @@ TaylorSeries v0.8.0
 Reexport v0.2.0
 DiffEqBase v4.21.3
 Espresso v0.5.1
+Requires

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Elliptic = "b305315f-e792-5b7a-8f41-49f472929428"
+DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 ParameterizedFunctions = "65888b18-ceab-5e60-b2b9-181511a3b968"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"

--- a/src/TaylorIntegration.jl
+++ b/src/TaylorIntegration.jl
@@ -3,29 +3,21 @@
 module TaylorIntegration
 
 using Reexport
-@reexport using TaylorSeries, DiffEqBase
+@reexport using TaylorSeries
 using LinearAlgebra
 using Markdown
+using Requires
 
-
-const warnkeywords =
-    (:save_idxs, :d_discontinuities, :unstable_check, :save_everystep,
-     :save_end, :initialize_save, :adaptive, :dt, :reltol, :dtmax,
-     :dtmin, :force_dtmin, :internalnorm, :gamma, :beta1, :beta2,
-     :qmax, :qmin, :qsteady_min, :qsteady_max, :qoldinit, :failfactor,
-     :maxiters, :isoutofdomain, :unstable_check,
-     :calck, :progress, :timeseries_steps, :tstops, :saveat, :dense)
-
-function __init__()
-    global warnlist = Set(warnkeywords)
-end
 
 export taylorinteg, lyap_taylorinteg, @taylorize
 
 include("explicitode.jl")
 include("lyapunovspectrum.jl")
-include("common.jl")
 include("rootfinding.jl")
 include("parse_eqs.jl")
+
+function __init__()
+    @require DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e" include("common.jl")
+end
 
 end #module

--- a/src/common.jl
+++ b/src/common.jl
@@ -1,3 +1,19 @@
+using DiffEqBase
+
+import DiffEqBase: ODEProblem, solve
+
+const warnkeywords =
+    (:save_idxs, :d_discontinuities, :unstable_check, :save_everystep,
+     :save_end, :initialize_save, :adaptive, :dt, :reltol, :dtmax,
+     :dtmin, :force_dtmin, :internalnorm, :gamma, :beta1, :beta2,
+     :qmax, :qmin, :qsteady_min, :qsteady_max, :qoldinit, :failfactor,
+     :maxiters, :isoutofdomain, :unstable_check,
+     :calck, :progress, :timeseries_steps, :tstops, :saveat, :dense)
+
+global warnlist = Set(warnkeywords)
+
+
+
 abstract type TaylorAlgorithm <: DiffEqBase.DEAlgorithm end
 struct TaylorMethod <: TaylorAlgorithm
     order::Int

--- a/test/common.jl
+++ b/test/common.jl
@@ -1,4 +1,4 @@
-using TaylorIntegration, Test
+using TaylorIntegration, Test, DiffEqBase
 using LinearAlgebra: norm
 
 f(u,p,t) = u


### PR DESCRIPTION
In https://github.com/JuliaIntervals/TaylorModels.jl/issues/39 a problem related to ambiguous methods of `broadcasted` was reported. The problem has its origin in reexporting `DiffEqsBase.jl` by `TaylorIntegration.jl`. The solution proposed here is to conditionally load `DiffEqBase.jl`.