### PR TITLE
Update version to v0.6.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TaylorIntegration"
 uuid = "92b13dbe-c966-51a2-8445-caca9f8a7d42"
 repo = "https://github.com/PerezHz/TaylorIntegration.jl.git"
-version = "0.5.1"
+version = "0.6.0"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/src/TaylorIntegration.jl
+++ b/src/TaylorIntegration.jl
@@ -17,18 +17,6 @@ include("rootfinding.jl")
 include("parse_eqs.jl")
 
 function __init__()
-    # Remember to delete this message when we release the next minor/major version
-    @warn("""\n\n
-        # Breaking changes
-
-        `TaylorIntegration.jl` follows now (≥ v0.5.0) the convention
-        of `DifferentialEquations.jl` for the function containing
-        the differential equation to be integrated. The function
-        must have the form `f(x, p, t)` for one dependent variable,
-        or `f!(dx, x, p, t)` for several dependent variables, where
-        `dx` is mutated.\n
-    """)
-
     @require DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e" include("common.jl")
 end
 


### PR DESCRIPTION
This PR updates the version to v0.6.0 in Project.toml and removes `info` message about breaking changes in v0.5.0. If everything goes right travis-wise, this PR will be merged and v0.6.0 will be released.