### PR TITLE
`@taylorize`: add experimental support for `Threads.@threads`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ git:
 env:
   global:
     - DOCUMENTER_DEBUG=true ## Debug documentation in travis
-    - JULIA_NUM_THREADS=4 ## run Julia on four threads
+    - JULIA_NUM_THREADS=2 ## run Julia on two threads
 
 jobs:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,13 @@ notifications:
 git:
   depth: 99999999
 
+## run Julia on two threads
+env:
+  # JULIA_NUM_THREADS=2
+  matrix:
+    - JULIA_NUM_THREADS=1
+    - JULIA_NUM_THREADS=2
+
 ## Debug documentation in travis
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,9 @@ git:
 
 ## run Julia on two threads
 env:
-  JULIA_NUM_THREADS=4
+  matrix:
+    - JULIA_NUM_THREADS=2
+    - JULIA_NUM_THREADS=4
 
 ## Debug documentation in travis
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,4 +36,5 @@ jobs:
 
 after_success:
   # push coverage results to Coveralls and Codecov
-  - julia -e 'using Pkg; import TaylorIntegration; joinpath(dirname(pathof(TaylorIntegration)), ".."); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder()); Codecov.submit(Codecov.process_folder())'
+  - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
+  - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())'

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,7 @@ git:
 
 ## run Julia on two threads
 env:
-  # JULIA_NUM_THREADS=2
-  matrix:
-    - JULIA_NUM_THREADS=1
-    - JULIA_NUM_THREADS=2
+  JULIA_NUM_THREADS=4
 
 ## Debug documentation in travis
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,16 +17,10 @@ notifications:
 git:
   depth: 99999999
 
-## run Julia on two threads
-env:
-  matrix:
-    - JULIA_NUM_THREADS=2
-    - JULIA_NUM_THREADS=4
-
-## Debug documentation in travis
 env:
   global:
-    - DOCUMENTER_DEBUG=true
+    - DOCUMENTER_DEBUG=true ## Debug documentation in travis
+    - JULIA_NUM_THREADS=4 ## run Julia on four threads
 
 jobs:
   allow_failures:

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ repo = "https://github.com/PerezHz/TaylorIntegration.jl.git"
 version = "0.8.1"
 
 [deps]
-Threads = "2c2a2de0-fc20-5d86-a1c5-326378dc053c"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 Espresso = "6912e4f1-e036-58b0-9138-08d1e6358ea9"
@@ -26,7 +25,6 @@ TaylorSeries = "0.10.2"
 julia = "1"
 
 [extras]
-Threads = "2c2a2de0-fc20-5d86-a1c5-326378dc053c"
 Elliptic = "b305315f-e792-5b7a-8f41-49f472929428"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -34,4 +32,4 @@ TaylorSeries = "6aa5eb33-94cf-58f4-a9d0-e4b2c4fc25ea"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["TaylorSeries", "LinearAlgebra", "Test", "Elliptic", "InteractiveUtils", "Threads"]
+test = ["TaylorSeries", "LinearAlgebra", "Test", "Elliptic", "InteractiveUtils"]

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ repo = "https://github.com/PerezHz/TaylorIntegration.jl.git"
 version = "0.8.1"
 
 [deps]
+Threads = "2c2a2de0-fc20-5d86-a1c5-326378dc053c"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 Espresso = "6912e4f1-e036-58b0-9138-08d1e6358ea9"
@@ -25,6 +26,7 @@ TaylorSeries = "0.10.2"
 julia = "1"
 
 [extras]
+Threads = "2c2a2de0-fc20-5d86-a1c5-326378dc053c"
 Elliptic = "b305315f-e792-5b7a-8f41-49f472929428"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -32,4 +34,4 @@ TaylorSeries = "6aa5eb33-94cf-58f4-a9d0-e4b2c4fc25ea"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["TaylorSeries", "LinearAlgebra", "Test", "Elliptic", "InteractiveUtils"]
+test = ["TaylorSeries", "LinearAlgebra", "Test", "Elliptic", "InteractiveUtils", "Threads"]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,6 +14,12 @@ matrix:
   allow_failures:
   - julia_version: nightly
 
+## run Julia on two threads
+environment:
+  matrix:
+    - JULIA_NUM_THREADS: 1
+    - JULIA_NUM_THREADS: 2
+
 # branches:
 #   only:
 #     - master

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,11 +2,17 @@ environment:
   matrix:
   - julia_version: 1.0
   - julia_version: 1.3
+    JULIA_NUM_THREADS: 1 # single thread
+  - julia_version: 1.3
+    JULIA_NUM_THREADS: 2 # two threads
   - julia_version: 1.4
+    JULIA_NUM_THREADS: 1 # single thread
+  - julia_version: 1.4
+    JULIA_NUM_THREADS: 2 # two threads
   - julia_version: nightly
-  ## run Julia on two threads
-  - JULIA_NUM_THREADS: 1
-  - JULIA_NUM_THREADS: 2
+    JULIA_NUM_THREADS: 1 # single thread
+  - julia_version: nightly
+    JULIA_NUM_THREADS: 2 # two threads
 
 platform:
   - x64 # 64-bit

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,9 @@ environment:
   - julia_version: 1.3
   - julia_version: 1.4
   - julia_version: nightly
+  ## run Julia on two threads
+  - JULIA_NUM_THREADS: 1
+  - JULIA_NUM_THREADS: 2
 
 platform:
   - x64 # 64-bit
@@ -13,12 +16,6 @@ platform:
 matrix:
   allow_failures:
   - julia_version: nightly
-
-## run Julia on two threads
-environment:
-  matrix:
-    - JULIA_NUM_THREADS: 1
-    - JULIA_NUM_THREADS: 2
 
 # branches:
 #   only:

--- a/docs/src/taylorize.md
+++ b/docs/src/taylorize.md
@@ -208,6 +208,8 @@ list some limitations and advices.
 - Use `local` for internal parameters (simple constant values); this improves
   performance. Do not use it if the variable is Taylor expanded.
 
+- `@taylorize` supports multi-threading via `Threads.@threads`.
+
 It is recommended to skim `test/taylorize.jl`, which implements different
 cases.
 

--- a/docs/src/taylorize.md
+++ b/docs/src/taylorize.md
@@ -208,7 +208,12 @@ list some limitations and advices.
 - Use `local` for internal parameters (simple constant values); this improves
   performance. Do not use it if the variable is Taylor expanded.
 
-- `@taylorize` supports multi-threading via `Threads.@threads`.
+- `@taylorize` supports multi-threading via `Threads.@threads`. **WARNING**:
+  this feature is experimental. Since thread-safety depends on the definition
+  of each ODE, we cannot guarantee the resulting code to be thread-safe in
+  advance. The user should check the resulting code to ensure that it is indeed
+  thread-safe. For more information about multi-threading, the reader is
+  referred to the [Julia documentation](https://docs.julialang.org/en/v1/manual/parallel-computing#man-multithreading-1).
 
 It is recommended to skim `test/taylorize.jl`, which implements different
 cases.

--- a/src/parse_eqs.jl
+++ b/src/parse_eqs.jl
@@ -339,6 +339,15 @@ function _newfnbody(fnbody, fnargs, d_indx)
                 push!(newfnbody.args[end].args, loopbody)
                 append!(v_newindx, tmp_newindx)
                 append!(v_arraydecl, tmp_arraydecl)
+            elseif ex_head == :macrocall && ( ex.args[1] == :(Threads.var"@threads") || ex.args[1] == Symbol("@threads") )
+                push!(newfnbody.args, Expr(:macrocall, ex.args[1]))
+                push!(newfnbody.args[end].args, ex.args[2])
+                exx = ex.args[3]
+                push!(newfnbody.args[end].args, Expr(:for, exx.args[1]))
+                loopbody, tmp_newindx, tmp_arraydecl = _newfnbody( exx.args[2], fnargs, d_indx )
+                push!(newfnbody.args[end].args[end].args, loopbody)
+                append!(v_newindx, tmp_newindx)
+                append!(v_arraydecl, tmp_arraydecl)
             elseif ex_head == :if
                 # The first argument of an `if` expression is the condition, the
                 # second one is the block the condition is true, and the third

--- a/test/taylorize.jl
+++ b/test/taylorize.jl
@@ -1173,7 +1173,8 @@ end
                 if i == j
                 else
                     X[i,j] = q[i]-q[j]
-                    dq[N+j] = dq[N+j] + (μ[i]*X[i,j])
+                    temp = dq[N+j] + (μ[i]*X[i,j])
+                    dq[N+j] = temp
                 end #if i != j
             end #for, i
         end #for, j

--- a/test/taylorize.jl
+++ b/test/taylorize.jl
@@ -1173,14 +1173,10 @@ end
                 if i == j
                 else
                     X[i,j] = q[i]-q[j]
-                    temp_001 = accX[j] + (μ[i]*X[i,j])
-                    accX[j] = temp_001
+                    dq[N+j] = dq[N+j] + (μ[i]*X[i,j])
                 end #if i != j
             end #for, i
         end #for, j
-        for i in 1:N
-            dq[N+i] = accX[i]
-        end
         nothing
     end
 
@@ -1190,10 +1186,9 @@ end
         local _eltype_q_ = eltype(q)
         local μ = params
         X = Array{_eltype_q_}(undef, N, N)
-        accX = Array{_eltype_q_}(undef, N) #acceleration
         for j in 1:N
-            accX[j] = zero(q[1])
             dq[j] = q[N+j]
+            dq[N+j] = zero(q[1]) # initialize acceleration
         end
         #compute accelerations
         Threads.@threads for j in 1:N

--- a/test/taylorize.jl
+++ b/test/taylorize.jl
@@ -1162,27 +1162,24 @@ end
         local _eltype_q_ = eltype(q)
         local μ = params
         X = Array{_eltype_q_}(undef, N, N)
-        #Newtonian acceleration
-        newtonX = Array{_eltype_q_}(undef, N)
+        accX = Array{_eltype_q_}(undef, N) #acceleration
         for j in 1:N
-            newtonX[j] = zero(q[1])
+            accX[j] = zero(q[1])
             dq[j] = q[N+j]
         end
-        #compute point-mass Newtonian accelerations, all bodies
+        #compute accelerations
         for j in 1:N
             for i in 1:N
-                # i == j && continue
                 if i == j
                 else
                     X[i,j] = q[i]-q[j]
-                    temp_001 = newtonX[j] + (μ[i]*X[i,j])
-                    newtonX[j] = temp_001
+                    temp_001 = accX[j] + (μ[i]*X[i,j])
+                    accX[j] = temp_001
                 end #if i != j
             end #for, i
         end #for, j
-        #fill the equations of motion for everyone
         for i in 1:N
-            dq[N+i] = newtonX[i]
+            dq[N+i] = accX[i]
         end
         nothing
     end
@@ -1193,27 +1190,24 @@ end
         local _eltype_q_ = eltype(q)
         local μ = params
         X = Array{_eltype_q_}(undef, N, N)
-        #Newtonian acceleration
-        newtonX = Array{_eltype_q_}(undef, N)
+        accX = Array{_eltype_q_}(undef, N) #acceleration
         for j in 1:N
-            newtonX[j] = zero(q[1])
+            accX[j] = zero(q[1])
             dq[j] = q[N+j]
         end
-        #compute point-mass Newtonian accelerations, all bodies
+        #compute accelerations
         Threads.@threads for j in 1:N
             for i in 1:N
-                # i == j && continue
                 if i == j
                 else
                     X[i,j] = q[i]-q[j]
-                    temp_001 = newtonX[j] + (μ[i]*X[i,j])
-                    newtonX[j] = temp_001
+                    temp_001 = accX[j] + (μ[i]*X[i,j])
+                    accX[j] = temp_001
                 end #if i != j
             end #for, i
         end #for, j
-        #fill the equations of motion for everyone
         for i in 1:N
-            dq[N+i] = newtonX[i]
+            dq[N+i] = accX[i]
         end
         nothing
     end

--- a/test/taylorize.jl
+++ b/test/taylorize.jl
@@ -1130,9 +1130,9 @@ end
         nothing
     end
 
-    x01 = Taylor1.(rand(10), 10)
+    x01 = Taylor1.(rand(10), _order)
     dx01 = similar(x01)
-    t1 = Taylor1(10)
+    t1 = Taylor1(_order)
     xaux1 = similar(x01)
 
     x01p = deepcopy(x01)
@@ -1220,7 +1220,7 @@ end
 
     N = 200
     x0 = 10randn(2N)
-    t = Taylor1(25)
+    t = Taylor1(_order)
     μ = 1e-7rand(N)
     x = Taylor1.(x0, t.order)
     dx = similar(x)
@@ -1234,9 +1234,12 @@ end
     TaylorIntegration.jetcoeffs!(Val(harmosc1dchain_threads!), t_, x_, dx_, μ)
     @time TaylorIntegration.jetcoeffs!(Val(harmosc1dchain_threads!), t_, x_, dx_, μ)
 
-    # @btime TaylorIntegration.jetcoeffs!($Val(harmosc1dchain!), $t, $x, $dx, $μ)
-    # @btime TaylorIntegration.jetcoeffs!($Val(harmosc1dchain_threads!), $t_, $x_, $dx_, $μ)
-
     @test x == x_
     @test dx == dx_
+
+    tv, xv = taylorinteg(harmosc1dchain!, x0, t0, 100.0, _order, _abstol, μ, maxsteps=5)
+    tv_, xv_ = taylorinteg(harmosc1dchain_threads!, x0, t0, 100.0, _order, _abstol, μ, maxsteps=5)
+
+    @test tv == tv_
+    @test xv == xv_
 end

--- a/test/taylorize.jl
+++ b/test/taylorize.jl
@@ -1222,6 +1222,8 @@ end
     x_ = Taylor1.(x0, t.order)
     dx_ = similar(x_)
 
+    @show Threads.nthreads()
+
     TaylorIntegration.jetcoeffs!(Val(harmosc1dchain!), t, x, dx, μ)
     @time TaylorIntegration.jetcoeffs!(Val(harmosc1dchain!), t, x, dx, μ)
 


### PR DESCRIPTION
This PR allows experimental `Threads.@threads` support. Now the user may add `Threads.@threads` before `for` loops in the definition of an ODE when applying the `@taylorize` macro, e.g.:

```julia
@taylorize function f!(dq, q, params, t)
    Threads.@threads for i in 1:10
        dq[i] = q[i]
    end
    nothing
end
```
Also:
```julia
using Base.Threads
@taylorize function f!(dq, q, params, t)
    @threads for i in 1:10 # note there's no `Threads` prefix
        dq[i] = q[i]
    end
    nothing
end
```

I have added some elementary tests which currently only check consistent results on a single thread on travis; right now I'm experimenting with environment variables on travis to actually perform tests on multiple threads.