### PR TITLE
Change convention for the event function `g`

### DIFF
--- a/docs/src/root_finding.md
+++ b/docs/src/root_finding.md
@@ -3,7 +3,7 @@
 In this example, we shall illustrate how to construct a Poincaré map associated
 with the surface of section ``x=0``, ``\dot x>0``, for ``E=0.1025`` for the
 [Hénon-Heiles system](https://en.wikipedia.org/wiki/Hénon–Heiles_system). This is
-equivalent to find the roots of an appropriate function `g(t, x, dx)`. We
+equivalent to find the roots of an appropriate function `g(dx, x, params, t)`. We
 illustrate the implementation using many initial conditions (Monte
 Carlo like implementation), and then compare the results
 with the use of [jet transport techniques](@ref jettransport).
@@ -46,13 +46,13 @@ nothing # hide
 
 In order to be able to generate (random) initial conditions with the appropriate
 energy, we write a function `px`, which depends on `x`, `y`, `py` and
-the energy `E` that returns the value of `px>0` for which the initial
+the energy `E`, that returns the value of `px>0` for which the initial
 condition `[x, y, px, py]` has energy `E`:
 ```@example poincare
 # px: select px0>0 such that E=E0
 px(x, E) = sqrt(2(E-V(x[1], x[2]))-x[4]^2)
 
-# px!: in-place version of px; returns the initial condition
+# px!: in-place version of px; returns the modified initial condition `x0`
 function px!(x, E)
     mypx = px(x, E)
     x[3] = mypx
@@ -70,32 +70,26 @@ H(x0)
 ```
 
 The scalar function `g`, which may depend on the time `t`, the vector of dependent
-variables `x` and even the velocities `dx`, defines the surface of section by
-means of the condition `g(t, x, dx) == 0`. This function `g` should return a
-variable of type `eltype(x)`. In the particular case that the user wishes to
-discard a particular crossing (or crossings), the function `g` must then return
-a `nothing` value, as will be demonstrated below.
+variables `x`, the velocities `dx`, and perhaps some parameters `params`, following
+again the convention of `DifferentialEquations.jl`, defines the surface of section
+by means of the condition ``g(dx, x, params, t) = 0``. Internally, the function
+`g` is assumed to return a `Tuple{Bool, Taylor1{T}}`, where `T` corresponds to
+`eltype(x[1])` (`x::Vector{Taylor1{T}}`). In the particular case that the user
+wishes to discard a particular crossing (or crossings), the function `g` must return
+a `false` value, as will be illustrated below.
 
 For the present example, we are looking for crossings through the surface ``x=0``,
-which corresponds to `g(dx, x, p, t) = x[1]`. But since we are looking only for the
-crossings through ``x=0`` which also satisfy ``\dot x > 0``, we have to define
-`g` in such a way that the crossing is discarded *only* if ``\dot x < 0``. One
-way to achieve this, is to define `g` such that if ``\dot x > 0`` then `g`
-returns the value of `x[1]`; otherwise, if ``\dot x < 0``, then `g` returns a
-`nothing` value.
-
-Therefore, we define (following again the convention of `DifferentialEquations.jl`) the function `g` as
+which corresponds to `x[1]==0`, restricting the crossings to satisfy ``\dot x > 0``. i.e., `x[3]>0`. We thus define the function `g` as
 ```@example poincare
 # x=0, px>0 section
 function g(dx, x, p, t)
     px_ = constant_term(x[3])
     # if px > 0...
     if px_ > zero(px_)
-        # ...return x
-        return x[1]
+        return (true, x[1])
     else
         #otherwise, discard the crossing
-        return nothing
+        return (false, x[1])
     end
 end
 nothing # hide
@@ -128,7 +122,7 @@ for i in 1:nconds
     rand1 = rand()
     rand2 = rand()
     x_ini .= x0 .+ 0.005 .* [0.0, sqrt(rand1)*cos(2pi*rand2), 0.0, sqrt(rand1)*sin(2pi*rand2)]
-    px!(x_ini, E0)
+    px!(x_ini, E0)   # ensure initial energy is E0
 
     tv_i, xv_i, tvS_i, xvS_i, gvS_i = taylorinteg(henonheiles!, g, x_ini, 0.0, 135.0,
         25, 1e-25, maxsteps=30000);
@@ -196,9 +190,9 @@ function g(dx::Array{Taylor1{TaylorN{T}},1}, x::Array{Taylor1{TaylorN{T}},1},
         p, t) where {T<:Number}
     px_ = constant_term(constant_term(x[3]))
     if px_ > zero( T )
-        return x[1]
+        return (true, x[1])
     else
-        return nothing
+        return (false, x[1])
     end
 end
 nothing # hide
@@ -210,7 +204,8 @@ tvTN, xvTN, tvSTN, xvSTN, gvSTN = taylorinteg(henonheiles!, g, x0TN, 0.0, 135.0,
 nothing # hide
 ```
 
-We define some auxiliary arrays, and then make an animation with the results for plotting.
+We define some auxiliary arrays, and then make an animation with the results for
+plotting.
 ```@example poincare
 #some auxiliaries:
 xvSTNaa = Array{Array{TaylorN{Float64},1}}(undef, length(tvSTN)+1 );

--- a/test/rootfinding.jl
+++ b/test/rootfinding.jl
@@ -15,7 +15,7 @@ using LinearAlgebra: norm
         nothing
     end
 
-    g(dx, x, p, t) = x[2]
+    g(dx, x, p, t) = (true, x[2])
 
     t0 = 0.0
     x0 = [1.3, 0.0]


### PR DESCRIPTION
I am opening this to propose a different return convention for the function `g`, which is used in some methods which involve root-finding/event-detection functions. The motivation is to avoid the possibility of an error (which I describe below), which is solved by defining a different convention on what should the function `g` return.

First, I describe the possibility of an error: Following the example on [Poincare maps in the docs](https://perezhz.github.io/TaylorIntegration.jl/latest/root_finding/#Monte-Carlo-simulation-1), the function `g` returns either `x[1]` if `x[3]>0`, or `nothing`. (The Poincaré map is defined as `x[1]=0` with `x[3]>0`.) Then, [in this line](https://github.com/PerezHz/TaylorIntegration.jl/blob/8e031c4e77085f5567b7a504582f315329c869a7/src/rootfinding.jl#L195) and also [here](https://github.com/PerezHz/TaylorIntegration.jl/blob/8e031c4e77085f5567b7a504582f315329c869a7/src/rootfinding.jl#L296)), we may end up evaluating `zero(nothing)`, which throws a `MethodError`. 

(In pass, I'd like to note that both functions have slightly different arguments for the function `g` which I think should read in both cases `g(dx, x, params, t)`.)

My proposal is that `g` should return a tuple similar to `Tuple{Bool, Taylor1{T}}`, the first entry being the Boolean `x[3]>0` (for the example in the docs,) and the second, `x[1]`. 