### PR TITLE
Add tests to check that the parsed jetcoeffs! method is used

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -26,6 +26,7 @@ julia = "^1.0.0"
 
 [extras]
 Elliptic = "b305315f-e792-5b7a-8f41-49f472929428"
+InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 TaylorSeries = "6aa5eb33-94cf-58f4-a9d0-e4b2c4fc25ea"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ version = "0.8.0"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 Espresso = "6912e4f1-e036-58b0-9138-08d1e6358ea9"
+InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
@@ -30,4 +31,5 @@ TaylorSeries = "6aa5eb33-94cf-58f4-a9d0-e4b2c4fc25ea"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["TaylorSeries", "LinearAlgebra", "Test", "Elliptic"]
+test = ["TaylorSeries", "LinearAlgebra", "Test", "Elliptic", "InteractiveUtils"]
+]

--- a/Project.toml
+++ b/Project.toml
@@ -32,4 +32,3 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["TaylorSeries", "LinearAlgebra", "Test", "Elliptic", "InteractiveUtils"]
-]

--- a/src/TaylorIntegration.jl
+++ b/src/TaylorIntegration.jl
@@ -7,6 +7,7 @@ using Reexport
 using LinearAlgebra
 using Markdown
 using Requires
+using InteractiveUtils: methodswith
 
 
 export taylorinteg, lyap_taylorinteg, @taylorize

--- a/src/lyapunovspectrum.jl
+++ b/src/lyapunovspectrum.jl
@@ -259,14 +259,7 @@ function lyap_taylorinteg(f!, q0::Array{U,1}, t0::T, tmax::T,
     vⱼ = similar(aⱼ)
 
     # Determine if specialized jetcoeffs! method exists
-    parse_eqs = parse_eqs && (length(methods(jetcoeffs!)) > 2)
-    if parse_eqs
-        try
-            jetcoeffs!(Val(f!), t, view(x, 1:dof), view(dx, 1:dof), params)
-        catch
-            parse_eqs = false
-        end
-    end
+    parse_eqs = _determine_parsing!(parse_eqs, f!, t, view(x, 1:dof), view(dx, 1:dof), params)
 
     # Integration
     nsteps = 1
@@ -359,14 +352,7 @@ function lyap_taylorinteg(f!, q0::Array{U,1}, trange::AbstractVector{T},
     vⱼ = similar(aⱼ)
 
     # Determine if specialized jetcoeffs! method exists
-    parse_eqs = parse_eqs && (length(methods(jetcoeffs!)) > 2)
-    if parse_eqs
-        try
-            jetcoeffs!(Val(f!), t, view(x, 1:dof), view(dx, 1:dof), params)
-        catch
-            parse_eqs = false
-        end
-    end
+    parse_eqs = _determine_parsing!(parse_eqs, f!, t, view(x, 1:dof), view(dx, 1:dof), params)
 
     # Integration
     iter = 2

--- a/src/rootfinding.jl
+++ b/src/rootfinding.jl
@@ -185,14 +185,7 @@ function taylorinteg(f!, g, q0::Array{U,1}, t0::T, tmax::T,
     sign_tstep = copysign(1, tmax-t0)
 
     # Determine if specialized jetcoeffs! method exists
-    parse_eqs = parse_eqs && (length(methods(jetcoeffs!)) > 2)
-    if parse_eqs
-        try
-            jetcoeffs!(Val(f!), t, x, dx, params)
-        catch
-            parse_eqs = false
-        end
-    end
+    parse_eqs = _determine_parsing!(parse_eqs, f!, t, x, dx, params)
 
     # Some auxiliary arrays for root-finding/event detection/Poincaré surface of section evaluation
     g_tupl = g(dx, x, params, t)
@@ -295,14 +288,7 @@ function taylorinteg(f!, g, q0::Array{U,1}, trange::AbstractVector{T},
     @inbounds xv[:,1] .= q0
 
     # Determine if specialized jetcoeffs! method exists
-    parse_eqs = parse_eqs && (length(methods(jetcoeffs!)) > 2)
-    if parse_eqs
-        try
-            jetcoeffs!(Val(f!), t, x, dx, params)
-        catch
-            parse_eqs = false
-        end
-    end
+    parse_eqs = _determine_parsing!(parse_eqs, f!, t, x, dx, params)
 
     # Some auxiliary arrays for root-finding/event detection/Poincaré surface of section evaluation
     g_tupl = g(dx, x, params, t)

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -84,7 +84,7 @@ using Test
         ts = 0.0:pi:2pi
         zsol3 = taylorinteg(eqs3!, zz0, ts, _order, _abstol, maxsteps=1)
         @test size(zsol3) == (length(ts), length(zz0))
-        zsol3 = taylorinteg(eqs3!, zz0, tr, _order, _abstol, maxsteps=1, nothing)
+        zsol3 = taylorinteg(eqs3!, zz0, tr, _order, _abstol, nothing, maxsteps=1)
         @test size(zsol3) == (length(tr), length(zz0))
         ta = vec(tr)
         zsol3 = taylorinteg(eqs3!, zz0, ta, _order, _abstol, maxsteps=1)

--- a/test/taylorize.jl
+++ b/test/taylorize.jl
@@ -85,7 +85,7 @@ using Elliptic
         @test xT ≈ exact_sol(tT, b1, x0)
 
         # The macro returns a (parsed) jetcoeffs! function which yields an error and
-        # therefore it runs with the default jetcoeffs! methdo. A warining is issued.
+        # therefore it runs with the default jetcoeffs! method. A warning is issued.
         @taylorize function xdot2_err(x, p, t)
             b2 = 3
             return b2-x^2


### PR DESCRIPTION
... including methods in which it fails, despite the macro works.