### PR TITLE
Compatibility with DynamicalODEProblem

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -29,7 +29,8 @@ Elliptic = "b305315f-e792-5b7a-8f41-49f472929428"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 TaylorSeries = "6aa5eb33-94cf-58f4-a9d0-e4b2c4fc25ea"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["TaylorSeries", "LinearAlgebra", "Test", "Elliptic", "InteractiveUtils"]
+test = ["TaylorSeries", "LinearAlgebra", "Test", "Elliptic", "InteractiveUtils", "StaticArrays"]

--- a/src/common.jl
+++ b/src/common.jl
@@ -146,7 +146,12 @@ function DiffEqBase.solve(
       _t = t[2:end]
     end
 
-    if typeof(prob.u0) <: AbstractArray
+    if typeof(prob.u0) <: Array
+      _timeseries = Vector{uType}(undef, 0)
+      for i=start_idx:size(vectimeseries, 1)
+          push!(_timeseries, reshape(view(vectimeseries, i, :, )', sizeu))
+      end
+    elseif typeof(prob.u0) <: AbstractArray
       _timeseries = Vector{Vector{eltype(uType)}}(undef, 0)
       for i=start_idx:size(vectimeseries, 1)
           push!(_timeseries, reshape(view(vectimeseries, i, :, )', sizeu))

--- a/src/common.jl
+++ b/src/common.jl
@@ -147,7 +147,7 @@ function DiffEqBase.solve(
     end
 
     if typeof(prob.u0) <: AbstractArray
-      _timeseries = Vector{uType}(undef, 0)
+      _timeseries = Vector{Vector{eltype(uType)}}(undef, 0)
       for i=start_idx:size(vectimeseries, 1)
           push!(_timeseries, reshape(view(vectimeseries, i, :, )', sizeu))
       end

--- a/src/explicitode.jl
+++ b/src/explicitode.jl
@@ -418,7 +418,8 @@ function taylorinteg(f!, q0::Array{U,1}, t0::T, tmax::T, order::Int, abstol::T,
     sign_tstep = copysign(1, tmax-t0)
 
     # Determine if specialized jetcoeffs! method exists
-    parse_eqs = _determine_parsing!(parse_eqs, f!, t, x, dx, params)
+    # parse_eqs = _determine_parsing!(parse_eqs, f!, t, x, dx, params)
+    parse_eqs = false
 
     # Integration
     nsteps = 1

--- a/src/explicitode.jl
+++ b/src/explicitode.jl
@@ -623,7 +623,7 @@ for R in (:Number, :Integer)
                 parse_eqs=parse_eqs)
         end
 
-        function taylorinteg(f, q0::Array{S,1}, tt0::T, ttmax::U, order::Int, aabstol::V,
+        function taylorinteg(f, q0::AbstractArray{S,1}, tt0::T, ttmax::U, order::Int, aabstol::V,
                 params = nothing; maxsteps::Int=500, parse_eqs::Bool=true) where
                     {S<:$R, T<:Real, U<:Real, V<:Real}
 

--- a/test/common.jl
+++ b/test/common.jl
@@ -1,5 +1,6 @@
 using TaylorIntegration, Test, DiffEqBase
 using LinearAlgebra: norm
+using StaticArrays
 
 @testset "Testing `common.jl`" begin
 
@@ -75,5 +76,51 @@ using LinearAlgebra: norm
         # Using a `callback`
         prob2 = ODEProblem(f!, u0, tspan, callback=nothing)
         @test_throws ErrorException solve(prob2, TaylorMethod(10), abstol=1e-20)
+    end
+
+    @testset "Test integration of DynamicalODEPoblem" begin
+        function iip_q̇(dq,p,q,params,t)
+            dq[1] = p[1]
+            dq[2] = p[2]
+        end
+
+        function iip_ṗ(dp,p,q,params,t)
+            dp[1] = -q[1] * (1 + 2q[2])
+            dp[2] = -q[2] - (q[1]^2 - q[2]^2)
+        end
+
+        iip_q0 = [0.1, 0.]
+        iip_p0 = [0., 0.5]
+
+
+        function oop_q̇(p, q, params, t)
+            p
+        end
+
+        function oop_ṗ(p, q, params, t)
+            dp1 = -q[1] * (1 + 2q[2])
+            dp2 = -q[2] - (q[1]^2 - q[2]^2)
+            @SVector [dp1, dp2]
+        end
+
+        oop_q0 = @SVector [0.1, 0.]
+        oop_p0 = @SVector [0., 0.5]
+
+        T(p) = 1//2 * norm(p)^2
+        V(q) = 1//2 * (q[1]^2 + q[2]^2 + 2q[1]^2 * q[2]- 2//3 * q[2]^3)
+        H(p,q, params) = T(p) + V(q)
+
+        E = H(iip_p0, iip_q0, nothing)
+
+        energy_err(sol) = maximum(i->H([sol[1,i], sol[2,i]], [sol[3,i], sol[4,i]], nothing)-E, 1:length(sol.u))
+
+        iip_prob = DynamicalODEProblem(iip_ṗ, iip_q̇, iip_p0, iip_q0, (0., 100.))
+        oop_prob = DynamicalODEProblem(oop_ṗ, oop_q̇, oop_p0, oop_q0, (0., 100.))
+
+        sol1 = solve(iip_prob, TaylorMethod(50), abstol=1e-20)
+        @test energy_err(sol1) < 1e-10
+
+        sol2 = solve(oop_prob, TaylorMethod(50), abstol=1e-20)
+        @test energy_err(sol2) < 1e-10
     end
 end


### PR DESCRIPTION
This PR tries to make the minimal amount of changes required with compatibility with `DynamicalODEProblem`s. Unfortunately, the explicit `Array` conversions like
https://github.com/PerezHz/TaylorIntegration.jl/blob/f3575ee1caba43e21312062d960613ec2ccba325/src/explicitode.jl#L634

make this complicated.

With this PR, I tried to convert the `DynamicalODEFunctions` to something that can work with the plain `Array` representation. The next issue was that the creation of a `Val{f}`
https://github.com/PerezHz/TaylorIntegration.jl/blob/f3575ee1caba43e21312062d960613ec2ccba325/src/explicitode.jl#L256

would fail with the above created closure. I tried replicating the problem in the REPL, but the above worked and returned an empty method list, so I disable the check to continue.

The last problem was due to the fact that the result timeseries is created using `uType`, but this is no longer valid because the data representation was converted to `Array` as mentioned above. As a hack I used the `eltype` of `uType` to create a `Vector{Vector{eltype(uType)}}` structure.

With all these hacks I can successfully integrate a `DynamicalODEProblem` (in the in-place form).

cc: @ChrisRackauckas 