### PR TITLE
Minor simplification in parse_eqs.jl

### DIFF
--- a/src/parse_eqs.jl
+++ b/src/parse_eqs.jl
@@ -8,7 +8,7 @@ using Espresso: subs, simplify, ExGraph, ExH, to_expr, sanitize, genname,
 # Define some constants to create the new (parsed) functions
 # The (irrelevant) `nothing` below is there to have a :block Expr; deleted later
 const _HEAD_PARSEDFN_SCALAR = sanitize(:(
-function jetcoeffs!(::Val{__fn}, __tT::Taylor1{_T}, __x::Taylor1{_S}, __params) where
+function TaylorIntegration.jetcoeffs!(::Val{__fn}, __tT::Taylor1{_T}, __x::Taylor1{_S}, __params) where
         {_T<:Real, _S<:Number}
 
     order = __tT.order
@@ -17,7 +17,7 @@ end)
 );
 
 const _HEAD_PARSEDFN_VECTOR = sanitize(:(
-function jetcoeffs!( ::Val{__fn}, __tT::Taylor1{_T}, __x::AbstractVector{Taylor1{_S}},
+function TaylorIntegration.jetcoeffs!( ::Val{__fn}, __tT::Taylor1{_T}, __x::AbstractVector{Taylor1{_S}},
         __dx::AbstractVector{Taylor1{_S}}, __params) where {_T<:Real, _S<:Number}
 
     order = __tT.order
@@ -198,10 +198,6 @@ function _newhead(fn, fnargs)
         throw(ArgumentError(
         "Wrong number of arguments in the definition of the function $fn"))
     end
-
-    # Add `TaylorIntegration` (module name) to create a new method of `jetcoeffs!`
-    newfunction.args[1].args[1].args[1] =
-        Expr(:., :TaylorIntegration, :(:jetcoeffs!))
 
     # Delete the irrelevant `nothing`
     pop!(newfunction.args[2].args)


### PR DESCRIPTION
This PR adds the `TaylorIntegration` prefix to parsed `jetcoeffs!` methods directly in the corresponding header constants, making code in parse_eqs.jl a tiny bit easier to read.