### PR TITLE
Fix #106

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ TaylorSeries = "6aa5eb33-94cf-58f4-a9d0-e4b2c4fc25ea"
 [compat]
 DataStructures = "0.17.2"
 DiffEqBase = "6"
-Espresso = "0.6"
+Espresso = "0.6.1"
 Reexport = "0.2"
 Requires = "0.5.2, 1.0"
 TaylorSeries = "0.10.2"

--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,6 @@ TaylorSeries = "6aa5eb33-94cf-58f4-a9d0-e4b2c4fc25ea"
 [compat]
 DataStructures = "0.17.2"
 DiffEqBase = "6"
-Elliptic = "0.5, 1.0"
 Espresso = "0.6"
 Reexport = "0.2"
 Requires = "0.5.2, 1.0"
@@ -28,8 +27,9 @@ julia = "1"
 Elliptic = "b305315f-e792-5b7a-8f41-49f472929428"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 TaylorSeries = "6aa5eb33-94cf-58f4-a9d0-e4b2c4fc25ea"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["TaylorSeries", "LinearAlgebra", "Test", "Elliptic", "InteractiveUtils"]
+test = ["TaylorSeries", "LinearAlgebra", "Test", "Elliptic", "InteractiveUtils", "Pkg"]

--- a/Project.toml
+++ b/Project.toml
@@ -17,6 +17,7 @@ TaylorSeries = "6aa5eb33-94cf-58f4-a9d0-e4b2c4fc25ea"
 [compat]
 DataStructures = "0.17.2"
 DiffEqBase = "6"
+Elliptic = "0.5, 1.0"
 Espresso = "0.6.1"
 Reexport = "0.2"
 Requires = "0.5.2, 1.0"

--- a/src/parse_eqs.jl
+++ b/src/parse_eqs.jl
@@ -949,11 +949,10 @@ See the [documentation](@ref taylorize) for more details and limitations.
     results carefully.
 
 """
-macro taylorize( ex, debug=false )
-    nex = _make_parsed_jetcoeffs(ex, debug)
-    debug && println(nex)
-    quote
-        $(esc(ex))  # evals to calling scope the passed function
-        $(esc(nex)) # evals the new method of `TaylorIntegration.jetcoeffs!`
-    end
+macro taylorize( ex )
+    nex = _make_parsed_jetcoeffs(ex)
+    esc(quote
+        $ex  # evals to calling scope the passed function
+        $nex # evals the new method of `TaylorIntegration.jetcoeffs!`
+    end)
 end

--- a/src/parse_eqs.jl
+++ b/src/parse_eqs.jl
@@ -2,95 +2,8 @@
 
 # Load necessary components of Espresso
 using Espresso: subs, simplify, ExGraph, ExH, to_expr, sanitize, genname,
-    find_vars, findex, find_indices, isindexed, to_context, preprocess, @get,
-    rename_repeated, canonical, parse!, eval_tracked!, fuse_assigned,
-    parse_call_args, AbstractExGraph, ExNode, @get_or_create, get_caller_module,
-    add_renaming!, CONST_OPS, force_bitness
+    find_vars, findex, find_indices, isindexed
 
-mutable struct ExGraph_taylor <: AbstractExGraph
-    tape::Vector{ExNode}           # list of ExNode-s
-    idx::Dict{Symbol, ExNode}      # map from var name to its node in the graph
-    ctx::Dict{Any,Any}             # settings and caches
-end
-
-# an adapted version of Espresso.parse!; Copyright (c) 2016: Andrei Zhabinski, MIT-licensed
-parse_taylor!(g::ExGraph_taylor, ex::Expr) = parse_taylor!(g, ExH(ex))
-parse_taylor!(g::ExGraph_taylor, s::Symbol) = rename_repeated(g, s)
-
-function parse_taylor!(g::ExGraph_taylor, x::Number)
-    if haskey(g.ctx, :bitness)
-        x = force_bitness(x, Val(g.ctx[:bitness]))
-    end
-    var = push!(g, :constant, genname(), x; val=x)
-    return var
-end
-
-function parse_taylor!(gt::ExGraph_taylor, ex::ExH{:(=)})
-    lhs, rhs = ex.args
-    rhs = rename_repeated(gt, rhs)
-    dep = parse_taylor!(gt, rhs)
-    if isa(lhs, Symbol)
-        if haskey(gt, lhs)
-            lhs = add_renaming!(gt, lhs)
-        end
-        push!(gt, :(=), lhs, dep)
-        return lhs
-    elseif isa(lhs, Expr) && lhs.head == :tuple
-        last_vname = nothing
-        for (i, vname) in enumerate(lhs.args)
-            parse_taylor!(gt, :($vname = $dep[$i]))
-        end
-        return last_vname
-    else
-        error("LHS of $(Expr(ex)) is neither variable, nor tuple")
-    end
-end
-
-function parse_taylor!(g::ExGraph_taylor, ex::ExH{:call})
-    ex = rename_repeated(g, ex)
-    op = ex.args[1] # canonical_taylor(g.ctx[:mod], ex.args[1])
-    args, kw_args = parse_call_args(ex)
-    meta = isempty(kw_args) ? Dict() : Dict(:kw => kw_args)
-    deps = [parse_taylor!(g, arg) for arg in args]
-    pex = Expr(:call, op, deps...)
-    if op in CONST_OPS && isempty(meta)
-        var = push!(g, :constant, genname(), pex)
-    else
-        var = push!(g, :call, genname(), pex; meta=meta)
-    end
-    return var
-end
-
-# an adapted version of Espresso.ExGraph; Copyright (c) 2016: Andrei Zhabinski, MIT-licensed
-function ExGraph_taylor(; ctx=Dict(), inputs...)
-    ctx = to_context(ctx)
-    # @get_or_create(ctx, :mod, @__MODULE__)
-    @get_or_create(ctx, :mod, get_caller_module())
-    g = ExGraph_taylor(ExNode[], Dict(), ctx)
-    for (var, val) in inputs
-        push!(g, :input, var, var; val=val)
-    end
-    return g
-end
-
-function ExGraph_taylor(ex::Expr; fuse=true, ctx=Dict(), inputs...)
-    ex = preprocess(ex)
-    ctx = to_context(ctx)
-    g = ExGraph_taylor(;ctx=ctx, inputs...)
-    g.ctx[:expr] = ex
-    method = @get(g.ctx, :method, :parse)
-    if method == :parse
-        parse_taylor!(g, ex)
-    elseif method == :track
-        eval_tracked!(g, ex, inputs...)
-    else
-        error("Method $method is not supported")
-    end
-    if fuse
-        g = fuse_assigned(g)
-    end
-    return g
-end
 
 # Define some constants to create the new (parsed) functions
 # The (irrelevant) `nothing` below is there to have a :block Expr; deleted later
@@ -495,11 +408,9 @@ function _newfnbody(fnbody, fnargs, d_indx)
 
                 # Unfold AST graph
                 nex = deepcopy(ex)
-                # @show to_expr(ExGraph_taylor(simplify(ex)))
                 try
-                    nex = to_expr(ExGraph_taylor(simplify(ex)))
+                    nex = to_expr(ExGraph(simplify(ex)))
                 catch
-                    @show "catch ExGraph_taylor" ex
                     # copy `ex` as it is, if it is not "recognized"
                     push!(newfnbody.args, ex)
                     continue

--- a/src/parse_eqs.jl
+++ b/src/parse_eqs.jl
@@ -408,13 +408,14 @@ function _newfnbody(fnbody, fnargs, d_indx)
 
                 # Unfold AST graph
                 nex = deepcopy(ex)
-                try
-                    nex = to_expr(ExGraph(simplify(ex)))
-                catch
-                    # copy `ex` as it is, if it is not "recognized"
-                    push!(newfnbody.args, ex)
-                    continue
-                end
+                # try
+                #     nex = to_expr(ExGraph(simplify(ex)))
+                # catch
+                #     # copy `ex` as it is, if it is not "recognized"
+                #     push!(newfnbody.args, ex)
+                #     continue
+                # end
+                nex = to_expr(ExGraph(simplify(ex)))
                 push!(newfnbody.args, nex.args[2:end]...)
 
                 # Bookkeeping of indexed vars, to define assignements

--- a/test/TestPkg/Project.toml
+++ b/test/TestPkg/Project.toml
@@ -1,0 +1,7 @@
+name = "TestPkg"
+uuid = "87ba5f82-8271-4dfc-8d8f-dcd99beeaf9d"
+version = "0.1.0"
+
+[deps]
+InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+TaylorIntegration = "92b13dbe-c966-51a2-8445-caca9f8a7d42"

--- a/test/TestPkg/src/TestPkg.jl
+++ b/test/TestPkg/src/TestPkg.jl
@@ -1,0 +1,183 @@
+module TestPkg
+
+# __precompile__(false)
+
+using TaylorIntegration
+# using BenchmarkTools
+using InteractiveUtils
+
+order = 25
+N = 200
+x0 = 10randn(2N)
+μ = 1e-7rand(N)
+x0[N] = - sum(x0[1:N-1].*μ[1:N-1])/μ[N]
+x0[2N] = - sum(x0[N+1:2N-1].*μ[1:N-1])/μ[N]
+
+@taylorize xdot1(x, p, t) = b1-x^2
+
+@taylorize function f1!(dq, q, params, t)
+    local N = Int(length(q)/2)
+    local _eltype_q_ = eltype(q)
+    local μ = params
+    X = Array{_eltype_q_}(undef, N, N)
+    accX = Array{_eltype_q_}(undef, N) #acceleration
+    for j in 1:N
+        accX[j] = zero(q[1])
+        dq[j] = q[N+j]
+    end
+    #compute accelerations
+    for j in 1:N
+        for i in 1:N
+            if i == j
+            else
+                X[i,j] = q[i]-q[j]
+                temp_001 = accX[j] + (μ[i]*X[i,j])
+                accX[j] = temp_001
+            end #if i != j
+        end #for, i
+    end #for, j
+    for i in 1:N
+        dq[N+i] = accX[i]
+    end
+    nothing
+end
+
+function f2!(dq, q, params, t)
+    local N = Int(length(q)/2)
+    local _eltype_q_ = eltype(q)
+    local μ = params
+    X = Array{_eltype_q_}(undef, N, N)
+    accX = Array{_eltype_q_}(undef, N) #acceleration
+    for j in 1:N
+        accX[j] = zero(q[1])
+        dq[j] = q[N+j]
+    end
+    #compute accelerations
+    for j in 1:N
+        for i in 1:N
+            if i == j
+            else
+                X[i,j] = q[i]-q[j]
+                temp_001 = accX[j] + (μ[i]*X[i,j])
+                accX[j] = temp_001
+            end #if i != j
+        end #for, i
+    end #for, j
+    for i in 1:N
+        dq[N+i] = accX[i]
+    end
+    nothing
+end
+
+function TaylorIntegration.jetcoeffs!(::Val{f2!}, t::Taylor1{_T}, q::AbstractVector{Taylor1{_S}}, dq::AbstractVector{Taylor1{_S}}, params) where {_T <: Real, _S <: Number}
+    order = t.order
+    local N = Int(length(q) / 2)
+    local _eltype_q_ = eltype(q)
+    local μ = params
+    X = Array{_eltype_q_}(undef, N, N)
+    accX = Array{_eltype_q_}(undef, N)
+    for j = 1:N
+        accX[j] = Taylor1(zero(constant_term(q[1])), order)
+        dq[j] = Taylor1(identity(constant_term(q[N + j])), order)
+    end
+    tmp337 = Array{Taylor1{_S}}(undef, size(X))
+    tmp337 .= Taylor1(zero(_S), order)
+    temp_001 = Array{Taylor1{_S}}(undef, size(tmp337))
+    temp_001 .= Taylor1(zero(_S), order)
+    for j = 1:N
+        for i = 1:N
+            if i == j
+            else
+                X[i, j] = Taylor1(constant_term(q[i]) - constant_term(q[j]), order)
+                tmp337[i, j] = Taylor1(constant_term(μ[i]) * constant_term(X[i, j]), order)
+                temp_001[i, j] = Taylor1(constant_term(accX[j]) + constant_term(tmp337[i, j]), order)
+                accX[j] = Taylor1(identity(constant_term(temp_001[i, j])), order)
+            end
+        end
+    end
+    for i = 1:N
+        dq[N + i] = Taylor1(identity(constant_term(accX[i])), order)
+    end
+    for __idx = eachindex(q)
+        (q[__idx]).coeffs[2] = (dq[__idx]).coeffs[1]
+    end
+    for ord = 1:order - 1
+        ordnext = ord + 1
+        for j = 1:N
+            TaylorSeries.zero!(accX[j], q[1], ord)
+            TaylorSeries.identity!(dq[j], q[N + j], ord)
+        end
+        for j = 1:N
+            for i = 1:N
+                if i == j
+                else
+                    TaylorSeries.subst!(X[i, j], q[i], q[j], ord)
+                    TaylorSeries.mul!(tmp337[i, j], μ[i], X[i, j], ord)
+                    TaylorSeries.add!(temp_001[i, j], accX[j], tmp337[i, j], ord)
+                    TaylorSeries.identity!(accX[j], temp_001[i, j], ord)
+                end
+            end
+        end
+        for i = 1:N
+            TaylorSeries.identity!(dq[N + i], accX[i], ord)
+        end
+        for __idx = eachindex(q)
+            (q[__idx]).coeffs[ordnext + 1] = (dq[__idx]).coeffs[ordnext] / ordnext
+        end
+    end
+    return nothing
+end
+
+ex1 = :(function f3!(dq, q, params, t)
+local N = Int(length(q)/2)
+local _eltype_q_ = eltype(q)
+local μ = params
+X = Array{_eltype_q_}(undef, N, N)
+accX = Array{_eltype_q_}(undef, N) #acceleration
+for j in 1:N
+    accX[j] = zero(q[1])
+    dq[j] = q[N+j]
+end
+#compute accelerations
+for j in 1:N
+    for i in 1:N
+        if i == j
+        else
+            X[i,j] = q[i]-q[j]
+            temp_001 = accX[j] + (μ[i]*X[i,j])
+            accX[j] = temp_001
+        end #if i != j
+    end #for, i
+end #for, j
+for i in 1:N
+    dq[N+i] = accX[i]
+end
+nothing
+end)
+
+ex2 = :(xdot2(x, p, t) = b1-x^2)
+
+ex3 = :(function harm_osc!(dx, x, p, t)
+    local ω = p[1]
+    local ω2 = ω^2
+    dx[1] = x[2]
+    dx[2] = - (ω2 * x[1])
+    return nothing
+end)
+
+nex1 = TaylorIntegration._make_parsed_jetcoeffs(ex1)
+nex2 = TaylorIntegration._make_parsed_jetcoeffs(ex2)
+nex3 = TaylorIntegration._make_parsed_jetcoeffs(ex3)
+
+greet(f, parse_eqs) = begin
+    t = Taylor1(order)
+    x = Taylor1.(x0, t.order)
+    dx = similar(x)
+
+    @show @which TaylorIntegration.__jetcoeffs!(Val(parse_eqs), f, t, x, dx, similar(x), μ)
+    @show @which TaylorIntegration.jetcoeffs!(Val(f), t, x, dx, μ)
+    @show methods(TaylorIntegration.jetcoeffs!)
+    # @btime TaylorIntegration.__jetcoeffs!(Val($parse_eqs), $f, $t, $x, $dx, similar($x), μ)
+end
+
+end # module

--- a/test/taylorize.jl
+++ b/test/taylorize.jl
@@ -1244,14 +1244,14 @@ import Pkg
 
     # Issue 106: allow calls to macro from Julia packages
     @testset "Test @taylorize use in modules/packages" begin
-        Pkg.add(Pkg.PackageSpec(url="https://github.com/PerezHz/MyPkg", rev="c2ea4a0"))
-        using MyPkg
-        nex1_ = TaylorIntegration._make_parsed_jetcoeffs(MyPkg.ex1)
-        nex2_ = TaylorIntegration._make_parsed_jetcoeffs(MyPkg.ex2)
-        nex3_ = TaylorIntegration._make_parsed_jetcoeffs(MyPkg.ex3)
-        @test length(MyPkg.nex1.args[2].args) == length(nex1_.args[2].args)
-        @test length(MyPkg.nex2.args[2].args) == length(nex2_.args[2].args)
-        @test length(MyPkg.nex3.args[2].args) == length(nex3_.args[2].args)
-        Pkg.rm("MyPkg")
+        Pkg.develop(  Pkg.PackageSpec( path=joinpath(@__DIR__, "TestPkg") )  )
+        using TestPkg
+        nex1_ = TaylorIntegration._make_parsed_jetcoeffs(TestPkg.ex1)
+        nex2_ = TaylorIntegration._make_parsed_jetcoeffs(TestPkg.ex2)
+        nex3_ = TaylorIntegration._make_parsed_jetcoeffs(TestPkg.ex3)
+        @test length(TestPkg.nex1.args[2].args) == length(nex1_.args[2].args)
+        @test length(TestPkg.nex2.args[2].args) == length(nex2_.args[2].args)
+        @test length(TestPkg.nex3.args[2].args) == length(nex3_.args[2].args)
+        Pkg.rm("TestPkg")
     end
 end

--- a/test/taylorize.jl
+++ b/test/taylorize.jl
@@ -6,6 +6,7 @@ using LinearAlgebra: norm
 using InteractiveUtils: methodswith
 using Elliptic
 using Base.Threads
+import Pkg
 
 @testset "Testing `taylorize.jl`" begin
 
@@ -1240,4 +1241,18 @@ using Base.Threads
         @test xv == xv_
     end
 
+
+    # Issue 106: allow calls to macro from Julia packages
+    @testset "Test @taylorize use in modules/packages" begin
+        # Pkg.add(url="https://github.com/PerezHz/MyPkg", rev="f0f5868", preserve=Pkg.PRESERVE_ALL)
+        Pkg.develop(path="/Users/Jorge/projects/MyPkg")
+        using MyPkg
+        nex1_ = TaylorIntegration._make_parsed_jetcoeffs(MyPkg.ex1)
+        nex2_ = TaylorIntegration._make_parsed_jetcoeffs(MyPkg.ex2)
+        nex3_ = TaylorIntegration._make_parsed_jetcoeffs(MyPkg.ex3)
+        @test length(MyPkg.nex1.args[2].args) == length(nex1_.args[2].args)
+        @test length(MyPkg.nex2.args[2].args) == length(nex2_.args[2].args)
+        @test length(MyPkg.nex3.args[2].args) == length(nex3_.args[2].args)
+        Pkg.rm("MyPkg")
+    end
 end

--- a/test/taylorize.jl
+++ b/test/taylorize.jl
@@ -1244,7 +1244,7 @@ import Pkg
 
     # Issue 106: allow calls to macro from Julia packages
     @testset "Test @taylorize use in modules/packages" begin
-        Pkg.add(url="https://github.com/PerezHz/MyPkg", rev="c2ea4a0")
+        Pkg.add(Pkg.PackageSpec(url="https://github.com/PerezHz/MyPkg", rev="c2ea4a0"))
         using MyPkg
         nex1_ = TaylorIntegration._make_parsed_jetcoeffs(MyPkg.ex1)
         nex2_ = TaylorIntegration._make_parsed_jetcoeffs(MyPkg.ex2)

--- a/test/taylorize.jl
+++ b/test/taylorize.jl
@@ -1244,8 +1244,7 @@ import Pkg
 
     # Issue 106: allow calls to macro from Julia packages
     @testset "Test @taylorize use in modules/packages" begin
-        # Pkg.add(url="https://github.com/PerezHz/MyPkg", rev="f0f5868", preserve=Pkg.PRESERVE_ALL)
-        Pkg.develop(path="/Users/Jorge/projects/MyPkg")
+        Pkg.add(url="https://github.com/PerezHz/MyPkg", rev="c2ea4a0", preserve=Pkg.PRESERVE_ALL)
         using MyPkg
         nex1_ = TaylorIntegration._make_parsed_jetcoeffs(MyPkg.ex1)
         nex2_ = TaylorIntegration._make_parsed_jetcoeffs(MyPkg.ex2)

--- a/test/taylorize.jl
+++ b/test/taylorize.jl
@@ -1244,7 +1244,7 @@ import Pkg
 
     # Issue 106: allow calls to macro from Julia packages
     @testset "Test @taylorize use in modules/packages" begin
-        Pkg.add(url="https://github.com/PerezHz/MyPkg", rev="c2ea4a0", preserve=Pkg.PRESERVE_ALL)
+        Pkg.add(url="https://github.com/PerezHz/MyPkg", rev="c2ea4a0")
         using MyPkg
         nex1_ = TaylorIntegration._make_parsed_jetcoeffs(MyPkg.ex1)
         nex2_ = TaylorIntegration._make_parsed_jetcoeffs(MyPkg.ex2)

--- a/test/taylorize.jl
+++ b/test/taylorize.jl
@@ -1244,6 +1244,12 @@ import Pkg
 
     # Issue 106: allow calls to macro from Julia packages
     @testset "Test @taylorize use in modules/packages" begin
+        # TestPkg is a local (unregistered) Julia package which tests the use
+        # of @taylorize inside module TestPkg. We test the direct use of
+        # @taylorize, as well as _make_parsed_jetcoeffs, to check that
+        # everything is compiled fine. Finally, we check that the parsed
+        # jetcoeffs! expressions (nex1, nex2, nex3) generated from inside Test Pkg
+        # are equivalent to (nex_1, nex_2, nex_3) generated here
         Pkg.develop(  Pkg.PackageSpec( path=joinpath(@__DIR__, "TestPkg") )  )
         using TestPkg
         nex1_ = TaylorIntegration._make_parsed_jetcoeffs(TestPkg.ex1)


### PR DESCRIPTION
Since #106 was last closed, I've been able to trace that issue to [this line of code](https://github.com/dfdx/Espresso.jl/blob/76c899cbd19df6f18e10875439591368fbc9b679/src/utils.jl#L151) in Espresso.jl, where the use of `Core.eval` leads to a silent error when using `@taylorize` from inside a module via the use of `ExGraph` [here](https://github.com/PerezHz/TaylorIntegration.jl/blob/1f36a47362bfe4d74022f257d20f5a78b1eea110/src/parse_eqs.jl#L412). For the time being, I have been able to workaround this issue by re-implementing the relevant part of Espresso in TaylorIntegration without using `eval`, but a better solution might be to report this directly there to look for a better solution. So, current changes are not elegant, but they get the job done, as far as I could tell.