### PR TITLE
Update restricted three-body problem example

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -36,7 +36,6 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 TaylorSeries = "6aa5eb33-94cf-58f4-a9d0-e4b2c4fc25ea"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 
 [targets]
-test = ["TaylorSeries", "LinearAlgebra", "Test", "Elliptic", "InteractiveUtils", "Pkg", "StaticArrays", "BenchmarkTools"]
+test = ["TaylorSeries", "LinearAlgebra", "Test", "Elliptic", "InteractiveUtils", "Pkg", "StaticArrays"]

--- a/Project.toml
+++ b/Project.toml
@@ -36,6 +36,7 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 TaylorSeries = "6aa5eb33-94cf-58f4-a9d0-e4b2c4fc25ea"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 
 [targets]
-test = ["TaylorSeries", "LinearAlgebra", "Test", "Elliptic", "InteractiveUtils", "Pkg", "StaticArrays"]
+test = ["TaylorSeries", "LinearAlgebra", "Test", "Elliptic", "InteractiveUtils", "Pkg", "StaticArrays", "BenchmarkTools"]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,6 +1,8 @@
 [deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Elliptic = "b305315f-e792-5b7a-8f41-49f472929428"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+TaylorIntegration = "92b13dbe-c966-51a2-8445-caca9f8a7d42"

--- a/docs/src/common.md
+++ b/docs/src/common.md
@@ -75,11 +75,13 @@ The equations of motion for the PCR3BP are
 \end{aligned}
 ```
 
-We define this system of ODEs in a way that allows the use of the [`@taylorize`](@ref taylorize)
-macro from `TaylorIntegration.jl`, which under certain circumstances allows
-important speed-ups.
+We define this system of ODEs in a way that allows the use of the [`@taylorize`](@ref)
+macro from `TaylorIntegration.jl`, which for the present example allows
+important speed-ups. For more details about the specifics of the use of [`@taylorize`](@ref),
+see [this section](@ref taylorize).
 ```@example common
-function pcr3bp!(dq, q, param, t)
+using TaylorIntegration
+@taylorize function pcr3bp!(dq, q, param, t)
     local μ = param[1]
     local onemμ = 1 - μ
     x1 = q[1]-μ
@@ -112,7 +114,7 @@ zero-velocity curves on the ``x``-axis.
 ```@example common
 ZVC(x) =  -x^2/2 + V(x, zero(x)) # projection of the zero-velocity curves on the x-axis
 
-plot(ZVC, -2:0.001:2, label="zero-vel. curve", legend=:topleft)
+plot(ZVC, -2:0.001:2, label="zero-vel. curve", legend=:topleft, fmt = :png)
 plot!([-2, 2], [-1.58, -1.58], label="J0 = -1.58")
 ylims!(-1.7, -1.45)
 xlabel!("x")
@@ -154,26 +156,31 @@ H(q0) == J0
 
 Following the `DifferentialEquations.jl`
 [tutorial](http://docs.juliadiffeq.org/latest/tutorials/ode_example.html),
-we define an `ODEProblem` for the integration;
-`TaylorIntegration.jl` can be used via its common interface bindings with `DiffEqBase.jl`; both packages need to be loaded explicitly.
+we define an `ODEProblem` for the integration; `TaylorIntegration` can be used
+via its common interface bindings with `DiffEqBase.jl`; both packages need to
+be loaded explicitly.
 ```@example common
-tspan = (0.0, 1000.0)
+tspan = (0.0, 2000.0)
 p = [μ]
 
-using TaylorIntegration, DiffEqBase
+using DiffEqBase
 prob = ODEProblem(pcr3bp!, q0, tspan, p)
 ```
 
-We solve `prob` using a 25-th order Taylor method, with a local absolute tolerance ``\epsilon_\mathrm{tol} = 10^{-20}``.
+We solve `prob` using a 25-th order Taylor method, with a local absolute tolerance ``\epsilon_\mathrm{tol} = 10^{-15}``.
 ```@example common
-solT = solve(prob, TaylorMethod(25), abstol=1e-20);
+solT = solve(prob, TaylorMethod(25), abstol=1e-15);
 ```
 
 As mentioned above, we load `OrdinaryDiffEq` in order to solve the same problem `prob`
-now with the `Vern9` method, which the `DifferentialEquations.jl`
+now with the `Vern9` method, which the `DifferentialEquations`
 [documentation](http://docs.juliadiffeq.org/latest/solvers/ode_solve.html#Non-Stiff-Problems-1)
 recommends for high-accuracy (i.e., very low tolerance) integrations of
-non-stiff problems.
+non-stiff problems. Note that, besides setting an absolute tolerance `abstol=1e-15`,
+we're setting a relative tolerance `reltol=1e-15` [[2]](@ref refsPCR3BP). We have found that for the
+current problem this is a good balance between speed and accuracy for the `Vern9`
+method, i.e., the `Vern9` integration becomes noticeably slower (although more
+accurate) if either `abstol` or `reltol` are set to lower values.
 ```@example common
 using OrdinaryDiffEq
 
@@ -181,9 +188,9 @@ solV = solve(prob, Vern9(), abstol=1e-15, reltol=1e-15); #solve `prob` with the 
 ```
 
 We plot in the ``x-y`` synodic plane the solution obtained
-with `TaylorIntegration.jl`:
+with `TaylorIntegration`:
 ```@example common
-plot(solT, vars=(1, 2), linewidth=1)
+plot(solT, vars=(1, 2), linewidth=1, fmt = :png)
 scatter!([μ, -1+μ], [0,0], leg=false) # positions of the primaries
 xlims!(-1+μ-0.2, 1+μ+0.2)
 ylims!(-0.8, 0.8)
@@ -197,19 +204,15 @@ For comparison, we now plot the orbit corresponding to the
 solution obtained with the `Vern9()` integration; note that
 the scales are identical.
 ```@example common
-plot(solV, vars=(1, 2), linewidth=1)
+plot(solV, vars=(1, 2), linewidth=1, fmt = :png)
 scatter!([μ, -1+μ], [0,0], leg=false) # positions of the primaries
 xlims!(-1+μ-0.2, 1+μ+0.2)
 ylims!(-0.8, 0.8)
 xlabel!("x")
 ylabel!("y")
 ```
-We note that the orbits do not display the same qualitative features. In particular,
-the `Vern9()` integration displays an orbit which does not visit the secondary,
-as it was the case in the integration using Taylor's method, and stays far
-enough from ``m_1``. The question is which integration should we trust?
-
-We can obtain a quantitative comparison of the validity of both integrations
+We note that both orbits display the same qualitative features. We can obtain a
+quantitative comparison of the validity of both integrations
 through the preservation of the Jacobi constant:
 ```@example common
 ET = H.(solT.u)
@@ -221,58 +224,58 @@ nothing # hide
 
 We plot first the value of the Jacobi constant as function of time.
 ```@example common
-plot(solT.t, H.(solT.u), label="TaylorIntegration.jl")
+plot(solT.t, H.(solT.u), label="TaylorMethod(25)", fmt = :png)
 plot!(solV.t, H.(solV.u), label="Vern9()")
 xlabel!("t")
 ylabel!("H")
 ```
-Clearly, the integration with `Vern9()` does not conserve the Jacobi constant;
-actually, the fact that its value is strongly reduced leads to the artificial trapping
-displayed above around ``m_1``. We notice that the loss of conservation of the
-Jacobi constant is actually not related to a close approach with ``m_1``.
+In the scale shown we observe that, while both solutions
+display a preservation of the Jacobi constant to a certain degree, the `Vern9()`
+solution suffers sudden jumps during the integration.
 
 We now plot, in log scale, the `abs` of the absolute error in the Jacobi
 constant as a function of time, for both solutions:
 ```@example common
-plot(solT.t, abs.(δET), yscale=:log10, label="TaylorIntegration.jl")
+plot(solT.t, abs.(δET), yscale=:log10, label="TaylorMethod(25)", legend=:topleft, fmt = :png)
 plot!(solV.t, abs.(δEV), label="Vern9()")
-ylims!(10^-18, 10^4)
+ylims!(10^-18, 10^-8)
 xlabel!("t")
 ylabel!("dE")
 ```
-We notice that the Jacobi constant absolute error for the `TaylorIntegration.jl`
-solution remains bounded below ``5\times 10^{-14}``, despite of the fact that
-the solution displays many close approaches with ``m_2``.
+We notice that the Jacobi constant absolute error for the `TaylorMethod(25)`
+solution remains bounded below ``10^{-11}``, while the `Vern9()` solution
+displays sudden jumps earlier in the integration and has variations close to
+``10^{-9}``.
 
 Finally, we comment on the time spent by each integration.
 ```@example common
-@elapsed solve(prob, TaylorMethod(25), abstol=1e-20);
+@elapsed solve(prob, TaylorMethod(25), abstol=1e-15);
 ```
 ```@example common
 @elapsed solve(prob, Vern9(), abstol=1e-15, reltol=1e-15);
 ```
-The integration with `TaylorMethod()` takes *much longer* than that using
-`Vern9()`. Yet, as shown above, the former preserves the Jacobi constant
-to a high accuracy, whereas the latter
-solution loses accuracy in the sense of not conserving the Jacobi constant,
-which is an important property to trust the result of the integration.
+We notice that the `TaylorMethod(25)` integration and the `Vern9()` one
+have similar performances, with the latter performing slightly better. Yet, as
+shown above, the former preserves the Jacobi constant to a higher accuracy by
+at least one order of magnitude.
+
 A fairer comparison is obtained by pushing the native methods of `DiffEqs`
 to reach similar accuracy for the integral of motion, as the one
-obtained by `TaylorIntegration.jl`. Such comparable situation has
-a performance cost, which then makes `TaylorIntegration.jl` comparable
-or even faster in some cases; see [[2]](@ref refsPCR3BP).
+obtained by `TaylorIntegration`. For example, for the `Vern9()` method we
+can set `abstol=1e-20, reltol=1e-15` to get better accuracies. Such
+situation has a performance cost, which then makes `TaylorIntegration`
+comparable or even faster in some cases; see [[2]](@ref refsPCR3BP).
 
-Finally, as mentioned above, a way to improve the integration time in
-`TaylorIntegration` is using the macro [`@taylorize`](@ref); see
-[this section](@ref taylorize) for details. Under certain circumstances
-it is possible to improve the performance, also with the common interface
-with `DifferentialEquations`, which restricts some of the great
-flexibility that `DifferentialEquations` allows when writing the function
-containing the differential equations.
+Finally, as mentioned above, a crucial way in which `TaylorIntegration`
+provides high accuracy at competitive speeds is through the use of
+the [`@taylorize`](@ref) macro; see
+[this section](@ref taylorize) for details. Currently, `TaylorIntegration`
+supports the use of `@taylorize` via the common interface with
+`DifferentialEquations` only for in-place `ODEProblem`.
 
 
-### [References](@id refsPCR3BP)
+### [References and notes](@id refsPCR3BP)
 
 [1] Murray, Carl D., Stanley F. Dermott. Solar System dynamics. Cambridge University Press, 1999.
 
-[2] [SciMLBenchmarks.jl/DynamicalODE](https://benchmarks.sciml.ai/html/DynamicalODE/Henon-Heiles_energy_conservation_benchmark.html)
+[3] [SciMLBenchmarks.jl/DynamicalODE](https://benchmarks.sciml.ai/html/DynamicalODE/Henon-Heiles_energy_conservation_benchmark.html)

--- a/docs/src/common.md
+++ b/docs/src/common.md
@@ -224,7 +224,7 @@ nothing # hide
 
 We plot first the value of the Jacobi constant as function of time.
 ```@example common
-plot(solT.t, H.(solT.u), label="TaylorMethod(25)", fmt = :png)
+plot(solT.t, H.(solT.u), label="TaylorMethod(25)", fmt = :png, yformatter = :plain)
 plot!(solV.t, H.(solV.u), label="Vern9()")
 xlabel!("t")
 ylabel!("H")
@@ -236,9 +236,9 @@ solution suffers sudden jumps during the integration.
 We now plot, in log scale, the `abs` of the absolute error in the Jacobi
 constant as a function of time, for both solutions:
 ```@example common
-plot(solT.t, abs.(δET), yscale=:log10, label="TaylorMethod(25)", legend=:topleft, fmt = :png)
+plot(solT.t, abs.(δET), yscale=:log10, label="TaylorMethod(25)", legend=:topleft, fmt = :png, yformatter = :plain)
 plot!(solV.t, abs.(δEV), label="Vern9()")
-ylims!(10^-18, 10^-8)
+ylims!(10^-16, 10^-10)
 xlabel!("t")
 ylabel!("dE")
 ```
@@ -249,15 +249,20 @@ displays sudden jumps earlier in the integration and has variations close to
 
 Finally, we comment on the time spent by each integration.
 ```@example common
-@elapsed solve(prob, TaylorMethod(25), abstol=1e-15);
+using BenchmarkTools
+bT = @benchmark solve($prob, $(TaylorMethod(25)), abstol=1e-15)
+bV = @benchmark solve($prob, $(Vern9()), abstol=1e-15, reltol=1e-15)
+nothing # hide
 ```
 ```@example common
-@elapsed solve(prob, Vern9(), abstol=1e-15, reltol=1e-15);
+bT # TaylorMethod(25) benchmark
 ```
-We notice that the `TaylorMethod(25)` integration and the `Vern9()` one
-have similar performances, with the latter performing slightly better. Yet, as
-shown above, the former preserves the Jacobi constant to a higher accuracy by
-at least one order of magnitude.
+```@example common
+bV # Vern9 benchmark
+```
+We notice that the `TaylorMethod(25)` and the `Vern9()` integrations perform
+similarly. Yet, as shown above, the former preserves the Jacobi constant to a
+higher accuracy by about one order of magnitude.
 
 A fairer comparison is obtained by pushing the native methods of `DiffEqs`
 to reach similar accuracy for the integral of motion, as the one

--- a/docs/src/common.md
+++ b/docs/src/common.md
@@ -283,4 +283,4 @@ supports the use of `@taylorize` via the common interface with
 
 [1] Murray, Carl D., Stanley F. Dermott. Solar System dynamics. Cambridge University Press, 1999.
 
-[3] [SciMLBenchmarks.jl/DynamicalODE](https://benchmarks.sciml.ai/html/DynamicalODE/Henon-Heiles_energy_conservation_benchmark.html)
+[2] [SciMLBenchmarks.jl/DynamicalODE](https://benchmarks.sciml.ai/html/DynamicalODE/Henon-Heiles_energy_conservation_benchmark.html)

--- a/docs/src/common.md
+++ b/docs/src/common.md
@@ -94,8 +94,8 @@ using TaylorIntegration
     r2_1p5 = (x2sq+ysq)^1.5
     dq[1] = q[3] + q[2]
     dq[2] = q[4] - q[1]
-    dq[3] = -((onemμ*x1)/r1_1p5) - ((μ*x2)/r2_1p5) + q[4]
-    dq[4] = -((onemμ*y )/r1_1p5) - ((μ*y )/r2_1p5) - q[3]
+    dq[3] = (-((onemμ*x1)/r1_1p5) - ((μ*x2)/r2_1p5)) + q[4]
+    dq[4] = (-((onemμ*y )/r1_1p5) - ((μ*y )/r2_1p5)) - q[3]
     return nothing
 end
 nothing # hide
@@ -155,7 +155,7 @@ H(q0) == J0
 ```
 
 Following the `DifferentialEquations.jl`
-[tutorial](http://docs.juliadiffeq.org/latest/tutorials/ode_example.html),
+[tutorial](https://diffeq.sciml.ai/stable/tutorials/ode_example/),
 we define an `ODEProblem` for the integration; `TaylorIntegration` can be used
 via its common interface bindings with `DiffEqBase.jl`; both packages need to
 be loaded explicitly.
@@ -163,7 +163,7 @@ be loaded explicitly.
 tspan = (0.0, 2000.0)
 p = [μ]
 
-using DiffEqBase
+using TaylorIntegration, DiffEqBase
 prob = ODEProblem(pcr3bp!, q0, tspan, p)
 ```
 
@@ -174,7 +174,7 @@ solT = solve(prob, TaylorMethod(25), abstol=1e-15);
 
 As mentioned above, we load `OrdinaryDiffEq` in order to solve the same problem `prob`
 now with the `Vern9` method, which the `DifferentialEquations`
-[documentation](http://docs.juliadiffeq.org/latest/solvers/ode_solve.html#Non-Stiff-Problems-1)
+[documentation](https://diffeq.sciml.ai/stable/solvers/ode_solve/#Non-Stiff-Problems)
 recommends for high-accuracy (i.e., very low tolerance) integrations of
 non-stiff problems. Note that, besides setting an absolute tolerance `abstol=1e-15`,
 we're setting a relative tolerance `reltol=1e-15` [[2]](@ref refsPCR3BP). We have found that for the
@@ -211,7 +211,9 @@ ylims!(-0.8, 0.8)
 xlabel!("x")
 ylabel!("y")
 ```
-We note that both orbits display the same qualitative features. We can obtain a
+We note that both orbits display the same qualitative features, and also some
+differences. For instance, the `TaylorMethod(25)` solution gets closer to the
+primary than that the `Vern9()`. We can obtain a
 quantitative comparison of the validity of both integrations
 through the preservation of the Jacobi constant:
 ```@example common
@@ -243,9 +245,9 @@ xlabel!("t")
 ylabel!("dE")
 ```
 We notice that the Jacobi constant absolute error for the `TaylorMethod(25)`
-solution remains bounded below ``2\times 10^{-14}``, while the `Vern9()` solution
-displays sudden jumps earlier in the integration and has variations larger than
-``10^{-13}``.
+solution remains bounded below ``10^{-13}``. The `Vern9()` solution is, at the
+end of the integration time, two orders of magnitude above the former for the
+same quantity.
 
 Finally, we comment on the time spent by each integration.
 ```@example common

--- a/docs/src/common.md
+++ b/docs/src/common.md
@@ -243,9 +243,9 @@ xlabel!("t")
 ylabel!("dE")
 ```
 We notice that the Jacobi constant absolute error for the `TaylorMethod(25)`
-solution remains bounded below ``10^{-11}``, while the `Vern9()` solution
-displays sudden jumps earlier in the integration and has variations close to
-``10^{-9}``.
+solution remains bounded below ``2\times 10^{-14}``, while the `Vern9()` solution
+displays sudden jumps earlier in the integration and has variations larger than
+``10^{-13}``.
 
 Finally, we comment on the time spent by each integration.
 ```@example common

--- a/docs/src/common.md
+++ b/docs/src/common.md
@@ -264,7 +264,7 @@ bV # Vern9 benchmark
 ```
 We notice that the `TaylorMethod(25)` and the `Vern9()` integrations perform
 similarly. Yet, as shown above, the former preserves the Jacobi constant to a
-higher accuracy by about one order of magnitude.
+higher accuracy by two orders of magnitude.
 
 A fairer comparison is obtained by pushing the native methods of `DiffEqs`
 to reach similar accuracy for the integral of motion, as the one

--- a/src/common.jl
+++ b/src/common.jl
@@ -230,3 +230,15 @@ function DiffEqBase.addsteps!(k, t, uprev, u, dt, f, p, cache::TaylorMethodCache
     update_jetcoeffs_cache!(u,f,p,cache)
     nothing
 end
+
+@inline __jetcoeffs!(::Val{false}, f::ODEFunction, t, x, params) =
+    jetcoeffs!(f.f, t, x, params)
+@inline __jetcoeffs!(::Val{true},  f::ODEFunction, t, x, params) =
+    jetcoeffs!(Val(f.f), t, x, params)
+@inline __jetcoeffs!(::Val{false}, f::ODEFunction, t, x, dx, xaux, params) =
+    jetcoeffs!(f.f, t, x, dx, xaux, params)
+@inline __jetcoeffs!(::Val{true},  f::ODEFunction, t, x, dx, xaux, params) =
+    jetcoeffs!(Val(f.f), t, x, dx, params)
+
+_determine_parsing!(parse_eqs::Bool, f::ODEFunction, t, x, params) = _determine_parsing!(parse_eqs::Bool, f.f, t, x, params)
+_determine_parsing!(parse_eqs::Bool, f::ODEFunction, t, x, dx, params) = _determine_parsing!(parse_eqs::Bool, f.f, t, x, dx, params)

--- a/test/common.jl
+++ b/test/common.jl
@@ -192,10 +192,11 @@ using StaticArrays
         end
         @test (@isdefined integ_vec)
         x0 = [0.0, 1.0]
-        tspan = (0.0, pi)
+        tspan = (0.0, 11pi)
         prob = ODEProblem(integ_vec, x0, tspan, [1.0])
         sol1 = solve(prob, TaylorMethod(order), abstol=abstol, parse_eqs=false)
         sol2 = solve(prob, TaylorMethod(order), abstol=abstol) # parse_eqs=true
+        @test sol2.alg.parse_eqs == true
         @test length(sol1.t) == length(sol2.t)
         @test sol1.t == sol2.t
         @test sol1.u == sol2.u
@@ -203,9 +204,8 @@ using StaticArrays
         @test sol1.t == tv
         @test sol1[1,:] == xv[:,1]
         @test sol1[2,:] == xv[:,2]
-        @test transpose(sol1[:,:]) == xv[:,:]
-        @test norm(sol1[end][1] - sin(sol1.t[end]), Inf) < 1.0e-15
-        @test norm(sol1[end][2] - cos(sol1.t[end]), Inf) < 1.0e-15
+        @test norm(sol1[end][1] - sin(sol1.t[end]), Inf) < 1.0e-14
+        @test norm(sol1[end][2] - cos(sol1.t[end]), Inf) < 1.0e-14
     end
 
     @testset "Test throwing errors in common interface" begin

--- a/test/common.jl
+++ b/test/common.jl
@@ -194,7 +194,6 @@ using StaticArrays
         @test sol1.alg.parse_eqs == false
         sol2 = solve(prob, TaylorMethod(order), abstol=abstol)
         @test sol2.alg.parse_eqs == true
-
         @test sol1.t == sol2.t
         @test sol1.u == sol2.u
 
@@ -248,10 +247,8 @@ using StaticArrays
         end
         prob = ODEProblem(pcr3bp!, q0, tspan, p)
         sol1 = solve(prob, TaylorMethod(order), abstol=abstol)
-        @time sol1 = solve(prob, TaylorMethod(order), abstol=abstol)
         @test sol1.alg.parse_eqs == true
         sol2 = solve(prob, TaylorMethod(order), abstol=abstol, parse_eqs=false)
-        @time sol2 = solve(prob, TaylorMethod(order), abstol=abstol, parse_eqs=false)
         @test sol2.alg.parse_eqs == false
         @test norm( H_pcr3bp(sol1.u[end]) - J0 ) < 1e-10
         @test norm( H_pcr3bp(sol2.u[end]) - J0 ) < 1e-10

--- a/test/common.jl
+++ b/test/common.jl
@@ -239,8 +239,8 @@ using StaticArrays
         sol2 = solve(prob, TaylorMethod(order), abstol=abstol, parse_eqs=false)
         @time sol2 = solve(prob, TaylorMethod(order), abstol=abstol, parse_eqs=false)
         @test sol2.alg.parse_eqs == false
-        @test norm( H_pcr3bp(sol1.u[end]) - J0 ) < 1e-12
-        @test norm( H_pcr3bp(sol2.u[end]) - J0 ) < 1e-12
+        @test norm( H_pcr3bp(sol1.u[end]) - J0 ) < 1e-10
+        @test norm( H_pcr3bp(sol2.u[end]) - J0 ) < 1e-10
         @test sol1.u == sol2.u
         @test sol1.t == sol2.t
     end


### PR DESCRIPTION
Fixes #125. Thanks to @lindnemi for the heads up! Incidentally, I found and fixed a bug which caused `parse_eqs` turn to `false` always when using the common interface.