### PR TITLE
Fix #160

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TaylorIntegration"
 uuid = "92b13dbe-c966-51a2-8445-caca9f8a7d42"
 repo = "https://github.com/PerezHz/TaylorIntegration.jl.git"
-version = "0.11.1"
+version = "0.12.0"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/Project.toml
+++ b/Project.toml
@@ -36,7 +36,6 @@ TaylorSeries = "0.14, 0.15"
 julia = "1"
 
 [extras]
-DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 Elliptic = "b305315f-e792-5b7a-8f41-49f472929428"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -47,4 +46,4 @@ TaylorSeries = "6aa5eb33-94cf-58f4-a9d0-e4b2c4fc25ea"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["DiffEqBase", "Elliptic", "InteractiveUtils", "LinearAlgebra", "Logging", "Pkg", "StaticArrays", "TaylorSeries", "Test"]
+test = ["Elliptic", "InteractiveUtils", "LinearAlgebra", "Logging", "Pkg", "StaticArrays", "TaylorSeries", "Test"]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,6 +1,5 @@
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
-DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Elliptic = "b305315f-e792-5b7a-8f41-49f472929428"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"

--- a/docs/src/common.md
+++ b/docs/src/common.md
@@ -2,18 +2,9 @@
 
 Here, we show an example of interoperability between `TaylorIntegration.jl` and
 [`DifferentialEquations.jl`](https://github.com/JuliaDiffEq/DifferentialEquations.jl), i.e.,
-how to use `TaylorIntegration.jl` from the `DifferentialEquations`
-ecosystem. The basic requirement is to load `DiffEqBase.jl`, or `OrdinaryDiffEq.jl`
-**before** `TaylorIntegration.jl`, which sets-up the common interface.
-
-!!! note
-    `TaylorIntegration.jl` may be loaded first, but then you **must** load `DiffEqBase.jl`
-    (and not `OrdinaryDiffEq.jl`); see
-    [#160](https://github.com/PerezHz/TaylorIntegration.jl/issues/160). Loading
-    `DiffEqBase.jl` or `OrdinaryDiffEq.jl` first, and then `TaylorIntegration.jl`,
-    pose no problem.
-
-Below, we shall also use `DiffEqBase.jl` to compare
+how to use `TaylorIntegration.jl` from the `DifferentialEquations` ecosystem. The basic
+requirement is to load `OrdinaryDiffEq.jl` together with `TaylorIntegration.jl`, which
+sets-up the common interface. Below, we shall also use `OrdinaryDiffEq.jl` to compare
 the accuracy of `TaylorIntegration.jl` with respect to
 high-accuracy methods for non-stiff problems (`Vern9` method).
 While `DifferentialEquations` offers many macros to simplify certain
@@ -165,13 +156,13 @@ H(q0) == J0
 Following the `DifferentialEquations.jl`
 [tutorial](https://diffeq.sciml.ai/stable/tutorials/ode_example/),
 we define an `ODEProblem` for the integration; `TaylorIntegration` can be used
-via its common interface bindings with `DiffEqBase.jl`; both packages need to
+via its common interface bindings with `OrdinaryDiffEq.jl`; both packages need to
 be loaded explicitly.
 ```@example common
 tspan = (0.0, 2000.0)
 p = [μ]
 
-using DiffEqBase
+using OrdinaryDiffEq
 prob = ODEProblem(pcr3bp!, q0, tspan, p)
 ```
 
@@ -180,8 +171,8 @@ We solve `prob` using a 25-th order Taylor method, with a local absolute toleran
 solT = solve(prob, TaylorMethod(25), abstol=1e-15);
 ```
 
-As mentioned above, we load `OrdinaryDiffEq` in order to solve the same problem `prob`
-now with the `Vern9` method, which the `DifferentialEquations`
+As mentioned above, we will now solve the same problem `prob`
+with the `Vern9` method from `OrdinaryDiffEq`, which the `DifferentialEquations`
 [documentation](https://diffeq.sciml.ai/stable/solvers/ode_solve/#Non-Stiff-Problems)
 recommends for high-accuracy (i.e., very low tolerance) integrations of
 non-stiff problems. Note that, besides setting an absolute tolerance `abstol=1e-15`,

--- a/docs/src/taylorize.md
+++ b/docs/src/taylorize.md
@@ -150,7 +150,7 @@ e1/e3, all1/all3
 We now illustrate the possibility of exploiting the macro
 when using `TaylorIntegration.jl` from `DifferentialEquations.jl`.
 ```@example taylorize
-using DiffEqBase
+using OrdinaryDiffEq
 
 prob = ODEProblem(pendulum!, q0, (t0, tf), nothing) # no parameters
 solT = solve(prob, TaylorMethod(25), abstol=1e-20, parse_eqs=true); # warm-up run

--- a/src/TaylorIntegration.jl
+++ b/src/TaylorIntegration.jl
@@ -18,9 +18,7 @@ include("lyapunovspectrum.jl")
 include("rootfinding.jl")
 
 function __init__()
-    @require DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e" begin
-        @require OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed" include("common.jl")
-    end
+    @require OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed" include("common.jl")
 end
 
 end #module

--- a/src/TaylorIntegration.jl
+++ b/src/TaylorIntegration.jl
@@ -18,7 +18,9 @@ include("lyapunovspectrum.jl")
 include("rootfinding.jl")
 
 function __init__()
-    @require DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e" include("common.jl")
+    @require DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e" begin
+        @require OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed" include("common.jl")
+    end
 end
 
 end #module

--- a/src/common.jl
+++ b/src/common.jl
@@ -2,7 +2,7 @@ using OrdinaryDiffEq
 using StaticArrays: SVector, SizedArray
 using RecursiveArrayTools: ArrayPartition
 
-import DiffEqBase: ODEProblem, solve, ODE_DEFAULT_NORM, @.., addsteps!
+import DiffEqBase: ODEProblem, solve, ODE_DEFAULT_NORM
 
 import OrdinaryDiffEq: OrdinaryDiffEqAdaptiveAlgorithm,
     OrdinaryDiffEqConstantCache, OrdinaryDiffEqMutableCache,

--- a/src/common.jl
+++ b/src/common.jl
@@ -1,13 +1,13 @@
-using DiffEqBase, OrdinaryDiffEq
+using OrdinaryDiffEq
 using StaticArrays: SVector, SizedArray
 using RecursiveArrayTools: ArrayPartition
 
 import DiffEqBase: ODEProblem, solve, ODE_DEFAULT_NORM, @.., addsteps!
 
 import OrdinaryDiffEq: OrdinaryDiffEqAdaptiveAlgorithm,
-OrdinaryDiffEqConstantCache, OrdinaryDiffEqMutableCache,
-alg_order, alg_cache, initialize!, perform_step!, @unpack,
-@cache, stepsize_controller!, step_accept_controller!, _ode_addsteps!
+    OrdinaryDiffEqConstantCache, OrdinaryDiffEqMutableCache,
+    alg_order, alg_cache, initialize!, perform_step!, @unpack,
+    @cache, stepsize_controller!, step_accept_controller!, _ode_addsteps!
 
 # TODO: check which keywords work fine
 const warnkeywords = (:save_idxs, :d_discontinuities, :unstable_check, :save_everystep,

--- a/test/common.jl
+++ b/test/common.jl
@@ -1,4 +1,4 @@
-using TaylorIntegration, Test, DiffEqBase
+using TaylorIntegration, Test, DiffEqBase, OrdinaryDiffEq
 using LinearAlgebra: norm
 using StaticArrays
 using Logging

--- a/test/common.jl
+++ b/test/common.jl
@@ -1,4 +1,5 @@
-using TaylorIntegration, Test, OrdinaryDiffEq
+using TaylorIntegration, Test
+using OrdinaryDiffEq
 using LinearAlgebra: norm
 using StaticArrays
 using Logging

--- a/test/common.jl
+++ b/test/common.jl
@@ -1,4 +1,4 @@
-using TaylorIntegration, Test, DiffEqBase, OrdinaryDiffEq
+using TaylorIntegration, Test, OrdinaryDiffEq
 using LinearAlgebra: norm
 using StaticArrays
 using Logging


### PR DESCRIPTION
This PR is another proposal to fix #160. What this PR does is essentially to `@require` directly `OrdinaryDiffEq` instead of `DiffEqBase`. Indeed, since in the common interface `TaylorMethod` is a subtype of `OrdinaryDiffEqAdaptiveAlgorithm`, then `TaylorIntegration` should actually be used together with `OrdinaryDiffEq` instead of `DiffEqBase` when using the common interface, as is currently documented. Tests are passing, so if we all agree this is a viable solution then I'll update the docs; otherwise this should be ready to merge.

cc: @lbenet @vram0gh