### PR TITLE
WIP: Optimize `@taylorize` for jet transport integrations

### DIFF
--- a/src/parse_eqs.jl
+++ b/src/parse_eqs.jl
@@ -158,11 +158,18 @@ function _make_parsed_jetcoeffs(ex::Expr)
     # rec_preamb: recursion loop for the preamble (first order correction)
     # rec_fnbody: recursion loop for the body-function (recursion loop for higher orders)
     rec_preamb, rec_fnbody = _recursionloop(fnargs, bkkeep)
+    rec_preamb = Expr(:macrocall, Symbol("@inbounds"),
+        LineNumberNode(@__LINE__, Symbol(@__FILE__)), rec_preamb)
+    rec_fnbody = Expr(:macrocall, Symbol("@inbounds"),
+        LineNumberNode(@__LINE__, Symbol(@__FILE__)), rec_fnbody)
 
     # Expr for the for-loop block for the recursion (of the `x` variable)
     forloopblock = Expr(:for, :(ord = 1:order-1), Expr(:block, :(ordnext = ord + 1)) )
+    forloopblock = Expr(:macrocall, Symbol("@inbounds"),
+        LineNumberNode(@__LINE__, Symbol(@__FILE__)), forloopblock)
     # Add rec_fnbody to forloopblock
-    push!(forloopblock.args[2].args, fnbody.args[1].args..., rec_fnbody)
+    # push!(forloopblock.args[2].args, fnbody.args[1].args..., rec_fnbody)
+    push!(forloopblock.args[3].args[2].args, fnbody.args[1].args..., rec_fnbody)
 
     # Add preamble and recursion body to `new_jetcoeffs`
     push!(new_jetcoeffs.args[2].args, defspreamble..., rec_preamb)

--- a/src/parse_eqs.jl
+++ b/src/parse_eqs.jl
@@ -808,13 +808,10 @@ function _replacecalls!(bkkeep::BookKeeping, fnold::Expr, newvar::Symbol)
             Dict(:_res => newvar, :_arg1 => :(constant_term($(newarg1))), :_k => :ord))
 
         def_fnexpr = Expr(:block,
-            :(_res.coeffs[1] = $(def_fnexpr.args[2])),
+            :($fnexpr),
             :(_res.coeffs[2:order+1] .= zero(_res.coeffs[1])) )
         def_fnexpr = subs(def_fnexpr,
-            Dict(:_res => newvar, :_arg1 => :(constant_term($(newarg1))), :_k => :ord))
-        # def_fnexpr = Expr(:block,
-        #     :(_res[0] = $(def_fnexpr.args[2])),
-        #     :(_res[1:order] .= zero(_res[0])) )
+            Dict(:_res => newvar, :_arg1 => newarg1, :ord => 0))
         # def_fnexpr = subs(def_fnexpr,
         #     Dict(:_res => newvar, :_arg1 => :(constant_term($(newarg1))), :_k => :ord))
 
@@ -827,12 +824,13 @@ function _replacecalls!(bkkeep::BookKeeping, fnold::Expr, newvar::Symbol)
                 Dict(:_res => newaux, :_arg1 => :(constant_term($(newarg1))), :_aux => newaux))
 
             aux_fnexpr = Expr(:block,
-                :(_res.coeffs[1] = $(aux_fnexpr.args[2])),
+                # :(_res.coeffs[1] = $(aux_fnexpr.args[2])),
                 :(_res.coeffs[2:order+1] .= zero(_res.coeffs[1])) )
             aux_fnexpr = subs(aux_fnexpr,
                 Dict(:_res => newaux, :_arg1 => :(constant_term($(newarg1))), :_aux => newaux))
 
             fnexpr = subs(fnexpr, Dict(:_aux => newaux))
+            def_fnexpr = subs(def_fnexpr, Dict(:_aux => newaux))
             if newvar ∈ bkkeep.v_arraydecl
                 push!(bkkeep.v_arraydecl, newaux)
             else
@@ -854,14 +852,10 @@ function _replacecalls!(bkkeep::BookKeeping, fnold::Expr, newvar::Symbol)
             :_arg2 => :(constant_term($(newarg2))), :_k => :ord) )
 
         def_fnexpr = Expr(:block,
-            :(_res.coeffs[1] = $(def_fnexpr.args[2])),
+            :($fnexpr),
             :(_res.coeffs[2:order+1] .= zero(_res.coeffs[1])) )
         def_fnexpr = subs(def_fnexpr,
-            Dict(:_res => newvar, :_arg1 => :(constant_term($(newarg1))),
-                :_arg2 => :(constant_term($(newarg2))), :_k => :ord))
-        # def_fnexpr = Expr(:block,
-        #     :(_res[0] = $(def_fnexpr.args[2])),
-        #     :(_res[1:order] .= zero(_res[0])) )
+            Dict(:_res => newvar, :_arg1 => newarg1, :_arg2 => newarg2, :ord => 0))
         # def_fnexpr = subs(def_fnexpr,
         #     Dict(:_res => newvar, :_arg1 => :(constant_term($(newarg1))),
         #         :_arg2 => :(constant_term($(newarg2))), :_k => :ord))

--- a/test/taylorize.jl
+++ b/test/taylorize.jl
@@ -1266,8 +1266,20 @@ import Logging: Warn
         @test newex1.args[2].args[2] == :(aa = __ralloc.v0[1])
         @test newex1.args[2].args[3] == :(aa = my_simple_function(q, p, t))
         @test newex2.args[2].args[2] == :(aa = my_simple_function(q, p, t))
-        @test newex1.args[2].args[6].args[2].args[2] ==
+        @test newex1.args[2].args[5].head == :macrocall
+        @test newex1.args[2].args[5].args[1] == Symbol("@inbounds")
+        @test newex1.args[2].args[5].args[2] ==
+            LineNumberNode(162, Symbol("/Users/benet/.julia/dev/TaylorIntegration/src/parse_eqs.jl"))
+        @test newex1.args[2].args[6].head == :macrocall
+        @test newex1.args[2].args[6].args[1] == Symbol("@inbounds")
+        @test newex1.args[2].args[6].args[2] ==
+            LineNumberNode(169, Symbol("/Users/benet/.julia/dev/TaylorIntegration/src/parse_eqs.jl"))
+        @test newex1.args[2].args[6].args[3].args[2].args[2] ==
             :(aa = my_simple_function(q, p, t))
+        @test newex1.args[2].args[6].args[3].args[2].args[4].head == :macrocall
+        @test newex1.args[2].args[6].args[3].args[2].args[4].args[1] == Symbol("@inbounds")
+        @test newex1.args[2].args[6].args[3].args[2].args[4].args[2] ==
+            LineNumberNode(164, Symbol("/Users/benet/.julia/dev/TaylorIntegration/src/parse_eqs.jl"))
 
         # Return line
         @test newex1.args[2].args[end] == :(return nothing)
@@ -1298,7 +1310,7 @@ import Logging: Warn
                 end
             end)
 
-        @test newex1.args[2].args[6].args[2].args[3] == Base.remove_linenums!(ex)
+        @test newex1.args[2].args[6].args[3].args[2].args[3] == Base.remove_linenums!(ex)
 
         # Throws no error
         ex = :(

--- a/test/taylorize.jl
+++ b/test/taylorize.jl
@@ -1268,18 +1268,12 @@ import Logging: Warn
         @test newex2.args[2].args[2] == :(aa = my_simple_function(q, p, t))
         @test newex1.args[2].args[5].head == :macrocall
         @test newex1.args[2].args[5].args[1] == Symbol("@inbounds")
-        @test newex1.args[2].args[5].args[2] ==
-            LineNumberNode(162, Symbol("/Users/benet/.julia/dev/TaylorIntegration/src/parse_eqs.jl"))
         @test newex1.args[2].args[6].head == :macrocall
         @test newex1.args[2].args[6].args[1] == Symbol("@inbounds")
-        @test newex1.args[2].args[6].args[2] ==
-            LineNumberNode(169, Symbol("/Users/benet/.julia/dev/TaylorIntegration/src/parse_eqs.jl"))
         @test newex1.args[2].args[6].args[3].args[2].args[2] ==
             :(aa = my_simple_function(q, p, t))
         @test newex1.args[2].args[6].args[3].args[2].args[4].head == :macrocall
         @test newex1.args[2].args[6].args[3].args[2].args[4].args[1] == Symbol("@inbounds")
-        @test newex1.args[2].args[6].args[3].args[2].args[4].args[2] ==
-            LineNumberNode(164, Symbol("/Users/benet/.julia/dev/TaylorIntegration/src/parse_eqs.jl"))
 
         # Return line
         @test newex1.args[2].args[end] == :(return nothing)


### PR DESCRIPTION
Currently, `@taylorize` optimizes allocations with respect to *time* (independent variable), but not with respect to the jet-transport variables (e.g., *initial conditions* or parameters), when such integration is performed. This makes that the number of allocations grow and performance is bad. 

This draft aims at improving that. My current idea is to create two new parsed functions which are specialized for `Taylor1{TaylorN{S}}` entries, mimicking what we do now. As I see it now, a new inner for-loop is needed (for each fixed order in the *time* loop), which runs over the order of the jet-transport variables.