### PR TITLE
Fix ATtaylotize initialization for arrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TaylorIntegration"
 uuid = "92b13dbe-c966-51a2-8445-caca9f8a7d42"
 repo = "https://github.com/PerezHz/TaylorIntegration.jl.git"
-version = "0.14.2"
+version = "0.14.3"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/src/parse_eqs.jl
+++ b/src/parse_eqs.jl
@@ -123,7 +123,7 @@ const _HEAD_ALLOC_TAYLOR1_VECTOR = sanitize(:(
 # Constants for the initial declaration and initialization of arrays
 const _DECL_ARRAY = sanitize( Expr(:block,
     :(__var1 = Array{Taylor1{_S}}(undef, __var2)),
-    :(__var1 .= Taylor1( zero(_S), order )))
+    :(__var1 .= Taylor1( zero(constant_term(__x[1])), order )))
 );
 
 


### PR DESCRIPTION
This is a minor change in `@taylorize` which initializes correctly the Taylor-arrays to zero, with respect to the order of the jet transport (`TaylorN`) variables.