### PR TITLE
Aqua: do not test ambiguities in Base and Core

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TaylorIntegration"
 uuid = "92b13dbe-c966-51a2-8445-caca9f8a7d42"
 repo = "https://github.com/PerezHz/TaylorIntegration.jl.git"
-version = "0.15.1"
+version = "0.15.2"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/test/aqua.jl
+++ b/test/aqua.jl
@@ -24,9 +24,10 @@ using Aqua
 end
 
 @testset "Aqua tests (additional)" begin
+    Aqua.test_ambiguities(TaylorIntegration)
     Aqua.test_all(
     TaylorIntegration;
+    ambiguities=false,
     stale_deps=(ignore=[:DiffEqBase, :RecursiveArrayTools, :Requires, :StaticArrays],),
     )
 end
-


### PR DESCRIPTION
When called via `Aqua.test_all`, `Aqua.test_ambiguities` tests ambiguities in Base and Core together with TaylorIntegration, but that produces lots of ambiguities coming from other packages. Currently, #178 tests are failing due to this. Similar to what we did in NEOs, this PR changes Aqua tests to avoid detecting ambiguities in Base and Core (which in turn are produced mainly by ForwardDiff.Dual, StatsBase.PValue and StatsBase.TestStat among others), which are currently not used here.