### PR TITLE
Two minor changes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TaylorIntegration"
 uuid = "92b13dbe-c966-51a2-8445-caca9f8a7d42"
 repo = "https://github.com/PerezHz/TaylorIntegration.jl.git"
-version = "0.17.0"
+version = "0.17.1"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/Project.toml
+++ b/Project.toml
@@ -40,7 +40,7 @@ RecursiveArrayTools = "2, 3"
 Reexport = "1"
 Requires = "1"
 StaticArrays = "0.12.5, 1"
-TaylorSeries = "0.19"
+TaylorSeries = "0.20"
 Test = "<0.0.1, 1"
 julia = "1.10"
 

--- a/src/TaylorIntegration.jl
+++ b/src/TaylorIntegration.jl
@@ -47,9 +47,10 @@ end
     res::Taylor1{Taylor1{T}},
     a::Taylor1{Taylor1{T}},
     k::Int,
-) where {T<:TaylorSeries.NumberNotSeries}
+) where {T<:TaylorSeries.NumberNotSeriesN}
     @inbounds for l in eachindex(a[k-1])
-        res[k][l] = a[k-1][l] / k
+        # res[k][l] = a[k-1][l] / k
+        TS.div!(res[k], a[k-1], k, l)
     end
     return nothing
 end

--- a/src/integrator/cache.jl
+++ b/src/integrator/cache.jl
@@ -414,16 +414,16 @@ function init_cache_lyap(
     return cache
 end
 
-# update!
+# update_cache!
 
-function update!(cache::ScalarCache, t0::T, x0::U) where {T,U}
+function update_cache!(cache::ScalarCache, t0::T, x0::U) where {T,U}
     @unpack t, x = cache
     @inbounds x[0] = x0
     @inbounds t[0] = t0
     return nothing
 end
 
-function update!(cache::AbstractVectorCache, t0::T, x0::Vector{U}) where {T,U}
+function update_cache!(cache::AbstractVectorCache, t0::T, x0::Vector{U}) where {T,U}
     @unpack t, x = cache
     @inbounds for i in eachindex(x0)
         x[i][0] = x0[i]

--- a/src/integrator/stepsize.jl
+++ b/src/integrator/stepsize.jl
@@ -17,7 +17,7 @@ Depending of `eltype(x)`, i.e., `U<:Number`, it may be necessary to overload
 function stepsize(x::Taylor1{U}, epsilon::T) where {T<:Real,U<:Number}
     R = promote_type(typeof(norm(constant_term(x), Inf)), T)
     ord = x.order
-    h = convert(R, Inf)
+    h = typemax(R)
     z = zero(R)
     for k in (ord - 1, ord)
         @inbounds aux = norm(x[k], Inf)
@@ -30,7 +30,7 @@ end
 
 function stepsize(q::AbstractArray{Taylor1{U},N}, epsilon::T) where {T<:Real,U<:Number,N}
     R = promote_type(typeof(norm(constant_term(q[1]), Inf)), T)
-    h = convert(R, Inf)
+    h = typemax(R)
     for i in eachindex(q)
         @inbounds hi = stepsize(q[i], epsilon)
         h = min(h, hi)

--- a/src/integrator/taylorinteg.jl
+++ b/src/integrator/taylorinteg.jl
@@ -103,7 +103,7 @@ function taylorinteg!(
     @unpack tv, xv, psol, t, x, rv, parse_eqs = cache
 
     # Initial conditions
-    update!(cache, t0, x0)
+    update_cache!(cache, t0, x0)
     nsteps = 1
     @inbounds tv[1] = t0
     @inbounds xv[1] = x0
@@ -117,7 +117,7 @@ function taylorinteg!(
         x0 = evaluate(x, δt) # new initial condition
         set_psol!(dense, psol, nsteps, x) # Store the Taylor polynomial solution
         t0 += δt
-        update!(cache, t0, x0)
+        update_cache!(cache, t0, x0)
         nsteps += 1
         @inbounds tv[nsteps] = t0
         @inbounds xv[nsteps] = x0
@@ -168,7 +168,7 @@ function taylorinteg!(
 
     # Initial conditions
     x0 = deepcopy(q0)
-    update!(cache, t0, x0)
+    update_cache!(cache, t0, x0)
     @inbounds tv[1] = t0
     @inbounds xv[:, 1] .= q0
     sign_tstep = copysign(1, tmax - t0)
@@ -182,7 +182,7 @@ function taylorinteg!(
         evaluate!(x, δt, x0) # new initial condition
         set_psol!(dense, psol, nsteps, x) # Store the Taylor polynomial solution
         t0 += δt
-        update!(cache, t0, x0)
+        update_cache!(cache, t0, x0)
         nsteps += 1
         @inbounds tv[nsteps] = t0
         @inbounds xv[:, nsteps] .= deepcopy.(x0)
@@ -322,7 +322,7 @@ function taylorinteg!(
 
     # Initial conditions
     @inbounds t0, t1, tmax = trange[1], trange[2], trange[end]
-    update!(cache, t0, x0)
+    update_cache!(cache, t0, x0)
     sign_tstep = copysign(1, tmax - t0)
     @inbounds xv[1] = x0
 
@@ -347,7 +347,7 @@ function taylorinteg!(
             break
         end
         t0 = tnext
-        update!(cache, t0, x0)
+        update_cache!(cache, t0, x0)
         nsteps += 1
         if nsteps > maxsteps
             @warn("""
@@ -395,7 +395,7 @@ function taylorinteg!(
     @inbounds t0, t1, tmax = trange[1], trange[2], trange[end]
     sign_tstep = copysign(1, tmax - t0)
     @inbounds x0 .= deepcopy(q0)
-    update!(cache, t0, x0)
+    update_cache!(cache, t0, x0)
     @inbounds xv[:, 1] .= q0
 
     # Integration
@@ -419,7 +419,7 @@ function taylorinteg!(
             break
         end
         t0 = tnext
-        update!(cache, t0, x0)
+        update_cache!(cache, t0, x0)
         nsteps += 1
         if nsteps > maxsteps
             @warn("""

--- a/src/lyapunovspectrum.jl
+++ b/src/lyapunovspectrum.jl
@@ -369,7 +369,7 @@ function lyap_taylorinteg!(
     sign_tstep = copysign(1, tmax - t0)
     x0[1:dof] .= q0
     @views x0[dof+1:end] .= jt[:]
-    update!(cache, t0, x0)
+    update_cache!(cache, t0, x0)
     t00 = t0
     tspan = zero(T)
     @inbounds tv[1] = t0
@@ -418,7 +418,7 @@ function lyap_taylorinteg!(
         for ind in eachindex(QH)
             @inbounds x0[dof+ind] = QH[ind]
         end
-        update!(cache, t0, x0)
+        update_cache!(cache, t0, x0)
         if nsteps > maxsteps
             @warn("""
             Maximum number of integration steps reached; exiting.
@@ -516,7 +516,7 @@ function lyap_taylorinteg!(
     sign_tstep = copysign(1, tmax - t0)
     x0[1:dof] .= q0
     @views x0[dof+1:end] .= jt[:]
-    update!(cache, t0, x0)
+    update_cache!(cache, t0, x0)
     t00 = t0
     tspan = zero(T)
     @inbounds for ind in eachindex(q0)
@@ -591,7 +591,7 @@ function lyap_taylorinteg!(
         for ind in eachindex(QH)
             @inbounds x0[dof+ind] = QH[ind]
         end
-        update!(cache, t0, x0)
+        update_cache!(cache, t0, x0)
         if nsteps > maxsteps
             @warn("""
             Maximum number of integration steps reached; exiting.

--- a/src/rootfinding.jl
+++ b/src/rootfinding.jl
@@ -295,7 +295,7 @@ function taylorinteg!(
 
     # Initial conditions
     x0 = deepcopy(q0)
-    update!(cache, t0, x0)
+    update_cache!(cache, t0, x0)
     @inbounds tv[1] = t0
     @inbounds xv[:, 1] .= deepcopy(q0)
     sign_tstep = copysign(1, tmax - t0)
@@ -348,7 +348,7 @@ function taylorinteg!(
         )
         g_tupl_old = deepcopy(g_tupl)
         t0 += δt
-        update!(cache, t0, x0)
+        update_cache!(cache, t0, x0)
         nsteps += 1
         @inbounds tv[nsteps] = t0
         @inbounds xv[:, nsteps] .= deepcopy(x0)
@@ -421,7 +421,7 @@ function taylorinteg!(
     @inbounds t0, t1, tmax = trange[1], trange[2], trange[end]
     sign_tstep = copysign(1, tmax - t0)
     @inbounds x0 .= deepcopy(q0)
-    update!(cache, t0, x0)
+    update_cache!(cache, t0, x0)
     @inbounds xv[:, 1] .= deepcopy(q0)
 
     # Some auxiliary arrays for root-finding/event detection/Poincaré surface of section evaluation
@@ -484,7 +484,7 @@ function taylorinteg!(
         )
         g_tupl_old = deepcopy(g_tupl)
         t0 = tnext
-        update!(cache, t0, x0)
+        update_cache!(cache, t0, x0)
         nsteps += 1
         if nsteps > maxsteps
             @warn("""


### PR DESCRIPTION
This PR proposes two minor changes:
- rename `update!` to `update_cache!`; TaylorSeries has a function called `update!`, so if both libraries are used one must qualify the module of the method used. I also think that the proposed name is more appropriate.
- In order to define the stepsize, we use the minimum, begining with a `convert(R,Inf)`. In this PR I propose to use `typemax(R)` (`R` is the proper type for the step size).
