### PR TITLE
Remove Function type restrictions

### DIFF
--- a/src/integrator/jetcoeffs.jl
+++ b/src/integrator/jetcoeffs.jl
@@ -2,7 +2,7 @@
 
 # jetcoeffs!
 @doc doc"""
-    jetcoeffs!(eqsdiff::Function, t, x, params)
+    jetcoeffs!(eqsdiff, t, x, params)
 
 Returns an updated `x` using the recursion relation of the
 derivatives obtained from the differential equations
@@ -21,7 +21,7 @@ computes recursively the high-order derivates back into `x`.
 
 """
 function jetcoeffs!(
-    eqsdiff::Function,
+    eqsdiff,
     t::Taylor1{T},
     x::Taylor1{U},
     params,
@@ -43,7 +43,7 @@ function jetcoeffs!(
 end
 
 @doc doc"""
-    jetcoeffs!(eqsdiff!::Function, t, x, dx, xaux, params)
+    jetcoeffs!(eqsdiff!, t, x, dx, xaux, params)
 
 Mutates `x` in-place using the recursion relation of the
 derivatives obtained from the differential equations
@@ -64,7 +64,7 @@ computes recursively the high-order derivates back into `x`.
 
 """
 function jetcoeffs!(
-    eqsdiff!::Function,
+    eqsdiff!,
     t::Taylor1{T},
     x::AbstractArray{Taylor1{U},N},
     dx::AbstractArray{Taylor1{U},N},


### PR DESCRIPTION
This minimal PR removes the  type restrictions from the  methods, allowing any callable object (functors, closures, etc.) to be used as differential equations.

## Changes
- Remove `::Function` from `jetcoeffs!(eqsdiff, ...)` 
- Remove `::Function` from `jetcoeffs!(eqsdiff!, ...)`

This makes TaylorIntegration.jl compatible with callable structs and other callable types, following modern Julia patterns. The change is fully backwards compatible.