### PR TITLE
Update `alg_cache` with verbosity toggle arg

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TaylorIntegration"
 uuid = "92b13dbe-c966-51a2-8445-caca9f8a7d42"
 repo = "https://github.com/PerezHz/TaylorIntegration.jl.git"
-version = "0.18.1"
+version = "0.18.2"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/ext/TaylorIntegrationDiffEqExt.jl
+++ b/ext/TaylorIntegrationDiffEqExt.jl
@@ -5,7 +5,6 @@ module TaylorIntegrationDiffEqExt
 using TaylorIntegration
 
 using OrdinaryDiffEq:
-    @cache,
     ODEFunction,
     DynamicalODEFunction,
     check_keywords,
@@ -13,6 +12,7 @@ using OrdinaryDiffEq:
     ODEProblem,
     DynamicalODEProblem
 using OrdinaryDiffEq.OrdinaryDiffEqCore
+using OrdinaryDiffEq.OrdinaryDiffEqCore: @cache
 import OrdinaryDiffEq
 
 using StaticArrays: SVector, SizedArray

--- a/ext/TaylorIntegrationDiffEqExt.jl
+++ b/ext/TaylorIntegrationDiffEqExt.jl
@@ -111,6 +111,7 @@ function ODEqCore.alg_cache(
     p,
     calck,
     ::Val{true},
+    ::ODEqCore.DEVerbosity
 )
     order = alg.order
     tT = Taylor1(typeof(t), order)
@@ -152,6 +153,7 @@ function ODEqCore.alg_cache(
     p,
     calck,
     ::Val{true},
+    ::ODEqCore.DEVerbosity
 )
     order = alg.order
     tT = Taylor1(typeof(t), order)
@@ -191,6 +193,7 @@ function ODEqCore.alg_cache(
     p,
     calck,
     ::Val{false},
+    ::ODEqCore.DEVerbosity
 )
     order = alg.order
     tT = Taylor1(typeof(t), order)

--- a/test/common.jl
+++ b/test/common.jl
@@ -12,6 +12,7 @@ using DiffEqBase
     local ODEqCore = OrdinaryDiffEq.OrdinaryDiffEqCore
     max_iters_reached() = "Maximum number of integration steps reached; exiting.\n"
     larger_maxiters_needed() =
+        "Verbosity toggle: max_iters \n " *
         "Interrupted. Larger maxiters is needed. If you " *
         "are using an integrator for non-stiff ODEs or an automatic switching " *
         "algorithm (the default), you may want to consider using a method for " *


### PR DESCRIPTION
SciML recently added a `DEVerbosity` type and added an arg to `alg_cache` related to this verbosity toggle. This PR updates the common interface accordingly.