### PR TITLE
Bump compat for OrdinaryDiffEq v7 / SciMLBase v3 ecosystem

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,15 +18,16 @@ TaylorSeries = "6aa5eb33-94cf-58f4-a9d0-e4b2c4fc25ea"
 [weakdeps]
 IntervalArithmetic = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
+SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 
 [extensions]
-TaylorIntegrationDiffEqExt = "OrdinaryDiffEq"
+TaylorIntegrationDiffEqExt = ["OrdinaryDiffEq", "SciMLBase"]
 TaylorIntegrationIAExt = "IntervalArithmetic"
 
 [compat]
 Aqua = "0.8"
 BenchmarkTools = "1.3"
-DiffEqBase = "6.210"
+DiffEqBase = "6.210, 7"
 Elliptic = "0.5, 1.0"
 Espresso = "0.6.1"
 InteractiveUtils = "<0.0.1, 1"
@@ -34,11 +35,12 @@ IntervalArithmetic = "0.23, 1"
 LinearAlgebra = "<0.0.1, 1"
 Logging = "<0.0.1, 1"
 Markdown = "<0.0.1, 1"
-OrdinaryDiffEq = "6"
+OrdinaryDiffEq = "6, 7"
 Parameters = "0.12"
 Pkg = "<0.0.1, 1"
 PkgBenchmark = "0.2"
-RecursiveArrayTools = "2, 3"
+RecursiveArrayTools = "2, 3, 4"
+SciMLBase = "2, 3"
 Reexport = "1"
 StaticArrays = "0.12.5, 1"
 TaylorSeries = "0.21"

--- a/ext/TaylorIntegrationDiffEqExt.jl
+++ b/ext/TaylorIntegrationDiffEqExt.jl
@@ -3,17 +3,16 @@
 module TaylorIntegrationDiffEqExt
 
 using TaylorIntegration
+using SciMLBase: SciMLBase
 
 using OrdinaryDiffEq:
     ODEFunction,
-    DynamicalODEFunction,
-    check_keywords,
-    warn_compat,
     ODEProblem,
     DynamicalODEProblem
 using OrdinaryDiffEq.OrdinaryDiffEqCore
 using OrdinaryDiffEq.OrdinaryDiffEqCore: @cache
 import OrdinaryDiffEq
+using SciMLBase: DynamicalODEFunction
 
 using StaticArrays: SVector, SizedArray
 using RecursiveArrayTools: ArrayPartition, copyat_or_push!
@@ -22,38 +21,6 @@ import DiffEqBase
 
 # TODO: check which keywords work fine
 const ODEqCore = OrdinaryDiffEq.OrdinaryDiffEqCore
-
-const warnkeywords = (
-    :save_idxs,
-    :d_discontinuities,
-    :unstable_check,
-    :save_everystep,
-    :save_end,
-    :initialize_save,
-    :adaptive,
-    :dt,
-    :dtmax,
-    :dtmin,
-    :force_dtmin,
-    :internalnorm,
-    :gamma,
-    :beta1,
-    :beta2,
-    :qmax,
-    :qmin,
-    :qsteady_min,
-    :qsteady_max,
-    :qoldinit,
-    :failfactor,
-    :isoutofdomain,
-    :unstable_check,
-    :calck,
-    :progress,
-    :timeseries_steps,
-)
-
-global warnlist = Set(warnkeywords)
-
 
 
 abstract type TaylorAlgorithm <: ODEqCore.OrdinaryDiffEqAdaptiveAlgorithm end
@@ -279,11 +246,6 @@ function DiffEqBase.solve(
 ) where {uType,tupType,isinplace}
 
     # SciMLBase.unwrapped_f(prob.f)
-
-    if verbose
-        warned = !isempty(kwargs) && check_keywords(alg, kwargs, warnlist)
-        warned && warn_compat()
-    end
 
     f = prob.f
     parse_eqs = haskey(kwargs, :parse_eqs) ? kwargs[:parse_eqs] : true # `true` is the default

--- a/test/common.jl
+++ b/test/common.jl
@@ -513,10 +513,17 @@ using DiffEqBase
         end
 
         function affect!(integrator, idx)
-            if idx == 1
-                integrator.u[2] = -0.9integrator.u[2]
-            elseif idx == 2
-                integrator.u[4] = -0.9integrator.u[4]
+            # idx is a Vector{Int8} in OrdinaryDiffEq v7 (element is ±1 if triggered, 0 otherwise)
+            # idx is a scalar Int in OrdinaryDiffEq v6
+            if idx isa AbstractVector
+                idx[1] != 0 && (integrator.u[2] = -0.9integrator.u[2])
+                idx[2] != 0 && (integrator.u[4] = -0.9integrator.u[4])
+            else
+                if idx == 1
+                    integrator.u[2] = -0.9integrator.u[2]
+                elseif idx == 2
+                    integrator.u[4] = -0.9integrator.u[4]
+                end
             end
         end
 


### PR DESCRIPTION
## Summary

This PR widens compat entries to allow the OrdinaryDiffEq v7 / SciMLBase v3 / DiffEqBase v7 / RecursiveArrayTools v4 ecosystem, which was released as part of the SciML ecosystem's major v7 upgrade. The current v0.18.3 caps at v6, making TaylorIntegration the leaf-level upstream blocker for packages that need v7 (e.g. ProbNumDiffEq.jl #419).

References: [SciML/OrdinaryDiffEq.jl NEWS.md](https://github.com/SciML/OrdinaryDiffEq.jl/blob/master/NEWS.md), SciML/OrdinaryDiffEq.jl#3562, SciML/OrdinaryDiffEq.jl#3565

## Compat changes

| Package | Old | New |
|---------|-----|-----|
| `DiffEqBase` | `"6.210"` | `"6.210, 7"` |
| `OrdinaryDiffEq` | `"6"` | `"6, 7"` |
| `RecursiveArrayTools` | `"2, 3"` | `"2, 3, 4"` |
| `SciMLBase` | _(not listed)_ | `"2, 3"` _(new, added as weakdep co-trigger)_ |

## Source migrations

### `ext/TaylorIntegrationDiffEqExt.jl`

1. **`DynamicalODEFunction` moved to `SciMLBase`** (was re-exported from `OrdinaryDiffEq` in v6, not in v7). Added `SciMLBase` as a weakdep and co-trigger for the `TaylorIntegrationDiffEqExt` extension so it can be declared as a dependency per Julia extension rules. The type is now imported via `using SciMLBase: DynamicalODEFunction`.

2. **`check_keywords` / `warn_compat` removed** from OrdinaryDiffEq v7 (keyword validation is now handled internally). Removed the call site (lines ~282–284) and the `warnkeywords`/`warnlist` constants.

### `test/common.jl`

3. **`VectorContinuousCallback` `affect!` signature change** (OrdinaryDiffEq v7 breaking change per NEWS.md): old API called `affect!(integrator, idx::Int)` once per triggered event index; new API calls `affect!(integrator, events::Vector{Int8})` once for all simultaneous events (each element is `±1` if triggered in that direction, `0` otherwise). Updated the test's `affect!` with `idx isa AbstractVector` dispatch to handle both v6 and v7 conventions (`test/common.jl:515–527`).

## Downstream unblocked

This unblocks ProbNumDiffEq.jl ([#419](https://github.com/nathanaelbosch/ProbNumDiffEq.jl/issues/419)) and any other package depending on TaylorIntegration that needs to use the v7-line SciML ecosystem.

## Test plan

- [x] `Pkg.test()` passes locally with OrdinaryDiffEq v7.0.0, DiffEqBase v7.0.0, SciMLBase v3.6.0, RecursiveArrayTools v4.2.0 (198 tests in `common.jl`, 324 in `rootfinding.jl`, 396 in `taylorize.jl`, all green)
- [ ] CI passes on GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)