### PR TITLE
Add minstepsize/maxstepsize keywords to all methods of `taylorinteg`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,11 +33,15 @@ jobs:
       matrix:
         version: ['1.10', '1', 'nightly']
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        arch:
-          - x64
         julia-threads:
           - '1'
         include:
+          - os: ubuntu-latest
+            arch: x64
+          - os: windows-latest
+            arch: x64
+          - os: macos-latest
+            arch: aarch64
           - os: ubuntu-latest
             version: '1'
             arch: x64
@@ -69,3 +73,16 @@ jobs:
         with:
           path-to-lcov: lcov.info
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          flag-name: run-${{ matrix.version }}-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.julia-threads }}
+          parallel: true
+  # New job to close the parallel build
+  coveralls_finish:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close Coveralls parallel build
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel-finished: trueUB_TOKEN }}
+          parallel-finished: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,11 +44,11 @@ jobs:
             julia-threads: '2'
     steps:
       - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
+      - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         env:
           cache-name: cache-artifacts
         with:
@@ -61,7 +61,7 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,5 +84,4 @@ jobs:
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          parallel-finished: trueUB_TOKEN }}
           parallel-finished: true

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "TaylorIntegration"
 uuid = "92b13dbe-c966-51a2-8445-caca9f8a7d42"
-version = "0.18.4"
+version = "0.18.5"
 repo = "https://github.com/PerezHz/TaylorIntegration.jl.git"
 
 [deps]

--- a/ext/TaylorIntegrationDiffEqExt.jl
+++ b/ext/TaylorIntegrationDiffEqExt.jl
@@ -232,8 +232,8 @@ end
 ODEqCore.get_fsalfirstlast(cache::TaylorMethodCache, u) = (cache.fsalfirst, cache.k)
 
 ODEqCore.stepsize_controller!(integrator, alg::TaylorMethodParams) =
-    TaylorIntegration.stepsize(integrator.cache.uT, integrator.opts.abstol,
-        integrator.opts.reltol, abs(integrator.opts.dtmin), abs(integrator.opts.dtmax))
+    clamp(TaylorIntegration.stepsize(integrator.cache.uT, integrator.opts.abstol,
+        integrator.opts.reltol), abs(integrator.opts.dtmin), abs(integrator.opts.dtmax))
 ODEqCore.step_accept_controller!(integrator, alg::TaylorMethodParams, q) = q
 
 function DiffEqBase.solve(
@@ -298,10 +298,11 @@ function DiffEqBase.solve(
         push!(kwargspairs, :dtmax => integrator.tdir * TType(Inf))
     end
     integrator = DiffEqBase.__init(_prob, _alg, args...; kwargs..., kwargspairs...)
+    # Override handle_dt! setting of initial dt
     integrator.dt =
         integrator.tdir *
-        TaylorIntegration.stepsize(integrator.cache.uT, integrator.opts.abstol, integrator.opts.reltol,
-            abs(integrator.opts.dtmin), abs(integrator.opts.dtmax)) # override handle_dt! setting of initial dt
+        clamp(TaylorIntegration.stepsize(integrator.cache.uT, integrator.opts.abstol,
+            integrator.opts.reltol), abs(integrator.opts.dtmin), abs(integrator.opts.dtmax))
     DiffEqBase.solve!(integrator)
     integrator.sol
 end

--- a/ext/TaylorIntegrationDiffEqExt.jl
+++ b/ext/TaylorIntegrationDiffEqExt.jl
@@ -232,7 +232,8 @@ end
 ODEqCore.get_fsalfirstlast(cache::TaylorMethodCache, u) = (cache.fsalfirst, cache.k)
 
 ODEqCore.stepsize_controller!(integrator, alg::TaylorMethodParams) =
-    TaylorIntegration.stepsize(integrator.cache.uT, integrator.opts.abstol, integrator.opts.reltol)
+    TaylorIntegration.stepsize(integrator.cache.uT, integrator.opts.abstol,
+        integrator.opts.reltol, abs(integrator.opts.dtmin), abs(integrator.opts.dtmax))
 ODEqCore.step_accept_controller!(integrator, alg::TaylorMethodParams, q) = q
 
 function DiffEqBase.solve(
@@ -247,10 +248,6 @@ function DiffEqBase.solve(
 
     f = prob.f
     parse_eqs = haskey(kwargs, :parse_eqs) ? kwargs[:parse_eqs] : true # `true` is the default
-    # Change default val of reltol to zdro, if not explicitly specified
-    if !haskey(kwargs, :reltol)
-        kwargs = (kwargs..., :reltol => zero(kwargs[:abstol]))
-    end
     if !isinplace && typeof(prob.u0) <: AbstractArray
         ### TODO: allow `parse_eqs=true` for DynamicalODEFunction
         if prob.f isa DynamicalODEFunction
@@ -283,11 +280,28 @@ function DiffEqBase.solve(
         _prob = prob
     end
 
-    # DiffEqBase.solve(prob, _alg, args...; kwargs...)
-    integrator = DiffEqBase.__init(_prob, _alg, args...; kwargs...)
+    # Change default val of reltol (to zero), dtmin (to zero(T)) and
+    # dtmax (to T(Inf)), if not explicitly specified
+    kwargspairs = Pair{Symbol, Number}[]
+    if !haskey(kwargs, :reltol)
+        # kwargs = (kwargs..., :reltol => zero(kwargs[:abstol]))
+        push!(kwargspairs, :reltol => zero(kwargs[:abstol]))
+    end
+    integrator = DiffEqBase.__init(_prob, _alg, args...)
+    TType = TS.numtype(integrator.t)
+    if !haskey(kwargs, :dtmin)
+        # kwargs = (kwargs..., :dtmin => zero(TType))
+        push!(kwargspairs, :dtmin => zero(TType))
+    end
+    if !haskey(kwargs, :dtmax)
+        # kwargs = (kwargs..., :dtmax => TType(Inf))
+        push!(kwargspairs, :dtmax => integrator.tdir * TType(Inf))
+    end
+    integrator = DiffEqBase.__init(_prob, _alg, args...; kwargs..., kwargspairs...)
     integrator.dt =
         integrator.tdir *
-        TaylorIntegration.stepsize(integrator.cache.uT, integrator.opts.abstol, integrator.opts.reltol) # override handle_dt! setting of initial dt
+        TaylorIntegration.stepsize(integrator.cache.uT, integrator.opts.abstol, integrator.opts.reltol,
+            abs(integrator.opts.dtmin), abs(integrator.opts.dtmax)) # override handle_dt! setting of initial dt
     DiffEqBase.solve!(integrator)
     integrator.sol
 end

--- a/ext/TaylorIntegrationIAExt.jl
+++ b/ext/TaylorIntegrationIAExt.jl
@@ -11,8 +11,7 @@ const IA = IntervalArithmetic
 
 # stepsize
 function TI.stepsize(x::Taylor1{Interval{U}}, absepsilon::T,
-        relepsilon::T=zero(T), minstep::T = zero(T),
-        maxstep::T = T(Inf)) where {T<:Real,U<:Number}
+                     relepsilon::T=zero(T)) where {T<:Real,U<:Number}
     x0 = constant_term(x)
     R = promote_type(IA.numtype(x0), T)#promote_type(typeof(norm(x0, Inf)), T)
     ord = get_order(x)
@@ -28,13 +27,11 @@ function TI.stepsize(x::Taylor1{Interval{U}}, absepsilon::T,
         end
         h = min(h, aux1)
     end
-    h = clamp(h, minstep, maxstep)
     return h::R
 end
 
 function TI.stepsize(q::AbstractArray{Taylor1{Interval{U}},N}, epsilon::T,
-                     relepsilon::T=zero(T), minstep::T = zero(T),
-                     maxstep::T = T(Inf)) where {T<:Real,U<:IA.NumTypes,N}
+                     relepsilon::T=zero(T)) where {T<:Real,U<:IA.NumTypes,N}
     R = promote_type(IA.numtype(constant_term(q[1])), T)#promote_type(typeof(norm(x0, Inf)), T)
     h = typemax(R)
     for i in eachindex(q)
@@ -52,7 +49,6 @@ function TI.stepsize(q::AbstractArray{Taylor1{Interval{U}},N}, epsilon::T,
             h = max(h, inf(hi))
         end
     end
-    h = clamp(h, minstep, maxstep)
     return h::R
 end
 

--- a/ext/TaylorIntegrationIAExt.jl
+++ b/ext/TaylorIntegrationIAExt.jl
@@ -11,7 +11,8 @@ const IA = IntervalArithmetic
 
 # stepsize
 function TI.stepsize(x::Taylor1{Interval{U}}, absepsilon::T,
-        relepsilon::T=zero(T)) where {T<:Real,U<:Number}
+        relepsilon::T=zero(T), minstep::T = zero(T),
+        maxstep::T = T(Inf)) where {T<:Real,U<:Number}
     x0 = constant_term(x)
     R = promote_type(IA.numtype(x0), T)#promote_type(typeof(norm(x0, Inf)), T)
     ord = get_order(x)
@@ -27,11 +28,13 @@ function TI.stepsize(x::Taylor1{Interval{U}}, absepsilon::T,
         end
         h = min(h, aux1)
     end
+    h = clamp(h, minstep, maxstep)
     return h::R
 end
 
 function TI.stepsize(q::AbstractArray{Taylor1{Interval{U}},N}, epsilon::T,
-        relepsilon::T=zero(T)) where {T<:Real,U<:IA.NumTypes,N}
+                     relepsilon::T=zero(T), minstep::T = zero(T),
+                     maxstep::T = T(Inf)) where {T<:Real,U<:IA.NumTypes,N}
     R = promote_type(IA.numtype(constant_term(q[1])), T)#promote_type(typeof(norm(x0, Inf)), T)
     h = typemax(R)
     for i in eachindex(q)
@@ -49,6 +52,7 @@ function TI.stepsize(q::AbstractArray{Taylor1{Interval{U}},N}, epsilon::T,
             h = max(h, inf(hi))
         end
     end
+    h = clamp(h, minstep, maxstep)
     return h::R
 end
 

--- a/src/integrator/stepsize.jl
+++ b/src/integrator/stepsize.jl
@@ -15,7 +15,7 @@ Depending of `eltype(x)`, i.e., `U<:Number`, it may be necessary to overload
 `stepsize`, specializing it on the type `U`, to avoid type instabilities.
 """
 function stepsize(x::Taylor1{U}, absepsilon::T, relepsilon::T = zero(T),
-                  minstep::T = zero(T), maxstep::T = T(Inf)) where {T<:Real,U<:Number}
+                  minstepsize::T = zero(T), maxstepsize::T = T(Inf)) where {T<:Real,U<:Number}
     x0 = constant_term(x)
     R = promote_type(typeof(norm(x0, Inf)), T)
     ord = get_order(x)
@@ -31,12 +31,12 @@ function stepsize(x::Taylor1{U}, absepsilon::T, relepsilon::T = zero(T),
         end
         h = min(h, aux1)
     end
-    h = clamp(h, minstep, maxstep)
+    h = clamp(h, minstepsize, maxstepsize)
     return h::R
 end
 
 function stepsize(q::AbstractArray{Taylor1{U},N}, absepsilon::T, relepsilon::T = zero(T),
-                  minstep::T = zero(T), maxstep::T = T(Inf)) where {T<:Real,U<:Number,N}
+                  minstepsize::T = zero(T), maxstepsize::T = T(Inf)) where {T<:Real,U<:Number,N}
     R = promote_type(typeof(norm(constant_term(q[1]), Inf)), T)
     h = typemax(R)
     for i in eachindex(q)
@@ -54,7 +54,7 @@ function stepsize(q::AbstractArray{Taylor1{U},N}, absepsilon::T, relepsilon::T =
             h = max(h, hi)
         end
     end
-    h = clamp(h, minstep, maxstep)
+    h = clamp(h, minstepsize, maxstepsize)
     return h::R
 end
 

--- a/src/integrator/stepsize.jl
+++ b/src/integrator/stepsize.jl
@@ -14,8 +14,8 @@ also the cases `Taylor1{TaylorN{U}}` and `Vector{Taylor1{TaylorN{U}}}`.
 Depending of `eltype(x)`, i.e., `U<:Number`, it may be necessary to overload
 `stepsize`, specializing it on the type `U`, to avoid type instabilities.
 """
-function stepsize(x::Taylor1{U}, absepsilon::T,
-        relepsilon::T=zero(T)) where {T<:Real,U<:Number}
+function stepsize(x::Taylor1{U}, absepsilon::T, relepsilon::T = zero(T),
+                  minstep::T = zero(T), maxstep::T = T(Inf)) where {T<:Real,U<:Number}
     x0 = constant_term(x)
     R = promote_type(typeof(norm(x0, Inf)), T)
     ord = get_order(x)
@@ -31,11 +31,12 @@ function stepsize(x::Taylor1{U}, absepsilon::T,
         end
         h = min(h, aux1)
     end
+    h = clamp(h, minstep, maxstep)
     return h::R
 end
 
-function stepsize(q::AbstractArray{Taylor1{U},N}, absepsilon::T,
-        relepsilon::T=zero(T)) where {T<:Real,U<:Number,N}
+function stepsize(q::AbstractArray{Taylor1{U},N}, absepsilon::T, relepsilon::T = zero(T),
+                  minstep::T = zero(T), maxstep::T = T(Inf)) where {T<:Real,U<:Number,N}
     R = promote_type(typeof(norm(constant_term(q[1]), Inf)), T)
     h = typemax(R)
     for i in eachindex(q)
@@ -53,6 +54,7 @@ function stepsize(q::AbstractArray{Taylor1{U},N}, absepsilon::T,
             h = max(h, hi)
         end
     end
+    h = clamp(h, minstep, maxstep)
     return h::R
 end
 

--- a/src/integrator/stepsize.jl
+++ b/src/integrator/stepsize.jl
@@ -14,8 +14,8 @@ also the cases `Taylor1{TaylorN{U}}` and `Vector{Taylor1{TaylorN{U}}}`.
 Depending of `eltype(x)`, i.e., `U<:Number`, it may be necessary to overload
 `stepsize`, specializing it on the type `U`, to avoid type instabilities.
 """
-function stepsize(x::Taylor1{U}, absepsilon::T, relepsilon::T = zero(T),
-                  minstepsize::T = zero(T), maxstepsize::T = T(Inf)) where {T<:Real,U<:Number}
+function stepsize(x::Taylor1{U}, absepsilon::T,
+                  relepsilon::T = zero(T)) where {T<:Real,U<:Number}
     x0 = constant_term(x)
     R = promote_type(typeof(norm(x0, Inf)), T)
     ord = get_order(x)
@@ -31,12 +31,11 @@ function stepsize(x::Taylor1{U}, absepsilon::T, relepsilon::T = zero(T),
         end
         h = min(h, aux1)
     end
-    h = clamp(h, minstepsize, maxstepsize)
     return h::R
 end
 
-function stepsize(q::AbstractArray{Taylor1{U},N}, absepsilon::T, relepsilon::T = zero(T),
-                  minstepsize::T = zero(T), maxstepsize::T = T(Inf)) where {T<:Real,U<:Number,N}
+function stepsize(q::AbstractArray{Taylor1{U},N}, absepsilon::T,
+                  relepsilon::T = zero(T),) where {T<:Real,U<:Number,N}
     R = promote_type(typeof(norm(constant_term(q[1]), Inf)), T)
     h = typemax(R)
     for i in eachindex(q)
@@ -54,7 +53,6 @@ function stepsize(q::AbstractArray{Taylor1{U},N}, absepsilon::T, relepsilon::T =
             h = max(h, hi)
         end
     end
-    h = clamp(h, minstepsize, maxstepsize)
     return h::R
 end
 

--- a/src/integrator/taylorinteg.jl
+++ b/src/integrator/taylorinteg.jl
@@ -81,12 +81,14 @@ function taylorinteg(
     parse_eqs::Bool = true,
     dense::Bool = true,
     reltol::T = zero(T),
+    minstep::T = zero(T),
+    maxstep::T = T(Inf)
 ) where {T<:Real,U<:Number}
 
     # Allocation
     cache = init_cache(Val(dense), t0, x0, maxsteps, order, f, params; parse_eqs)
 
-    return taylorinteg!(Val(dense), f, x0, t0, tmax, abstol, cache, params; maxsteps,reltol)
+    return taylorinteg!(Val(dense), f, x0, t0, tmax, abstol, cache, params; maxsteps, reltol, minstep, maxstep)
 end
 
 function taylorinteg!(
@@ -100,6 +102,8 @@ function taylorinteg!(
     params;
     maxsteps::Int = 500,
     reltol::T = zero(T),
+    minstep::T = zero(T),
+    maxstep::T = T(Inf)
 ) where {T<:Real,U<:Number,D}
 
     (; tv, xv, psol, t, x, rv, parse_eqs) = cache
@@ -113,7 +117,7 @@ function taylorinteg!(
 
     # Integration
     while sign_tstep * t0 < sign_tstep * tmax
-        δt = taylorstep!(Val(parse_eqs), f, t, x, abstol, params, rv, reltol) # δt is positive!
+        δt = taylorstep!(Val(parse_eqs), f, t, x, abstol, params, rv, reltol, minstep, maxstep) # δt is positive!
         # Below, δt has the proper sign according to the direction of the integration
         if iszero(δt)
             @warn("""The step-size is zero; aborting integration.""")
@@ -151,12 +155,14 @@ function taylorinteg(
     parse_eqs::Bool = true,
     dense::Bool = true,
     reltol::T = zero(T),
+    minstep::T = zero(T),
+    maxstep::T = T(Inf)
 ) where {T<:Real,U<:Number}
 
     # Allocation
     cache = init_cache(Val(dense), t0, q0, maxsteps, order, f!, params; parse_eqs)
 
-    return taylorinteg!(Val(dense), f!, q0, t0, tmax, abstol, cache, params; maxsteps, reltol)
+    return taylorinteg!(Val(dense), f!, q0, t0, tmax, abstol, cache, params; maxsteps, reltol, minstep, maxstep)
 end
 
 function taylorinteg!(
@@ -170,6 +176,8 @@ function taylorinteg!(
     params;
     maxsteps::Int = 500,
     reltol::T = zero(T),
+    minstep::T = zero(T),
+    maxstep::T = T(Inf)
 ) where {T<:Real,U<:Number,D}
 
     (; tv, xv, psol, xaux, t, x, dx, rv, parse_eqs) = cache
@@ -184,7 +192,7 @@ function taylorinteg!(
     # Integration
     nsteps = 1
     while sign_tstep * t0 < sign_tstep * tmax
-        δt = taylorstep!(Val(parse_eqs), f!, t, x, dx, xaux, abstol, params, rv, reltol) # δt is positive!
+        δt = taylorstep!(Val(parse_eqs), f!, t, x, dx, xaux, abstol, params, rv, reltol, minstep, maxstep) # δt is positive!
         # Below, δt has the proper sign according to the direction of the integration
         if iszero(δt)
             @warn("""The step-size is zero; aborting integration.""")
@@ -310,6 +318,8 @@ function taylorinteg(
     maxsteps::Int = 500,
     parse_eqs::Bool = true,
     reltol::T = zero(T),
+    minstep::T = zero(T),
+    maxstep::T = T(Inf)
 ) where {T<:Real,U<:Number}
 
     # Check if trange is increasingly or decreasingly sorted
@@ -318,7 +328,7 @@ function taylorinteg(
     # Allocation
     cache = init_cache(Val(false), trange, x0, maxsteps, order, f, params; parse_eqs)
 
-    return taylorinteg!(f, x0, trange, abstol, cache, params; maxsteps, reltol)
+    return taylorinteg!(f, x0, trange, abstol, cache, params; maxsteps, reltol, minstep, maxstep)
 end
 
 function taylorinteg!(
@@ -330,6 +340,8 @@ function taylorinteg!(
     params;
     maxsteps::Int = 500,
     reltol::T = zero(T),
+    minstep::T = zero(T),
+    maxstep::T = T(Inf)
 ) where {T<:Real,U<:Number}
 
     (; xv, t, x, rv, parse_eqs) = cache
@@ -344,7 +356,7 @@ function taylorinteg!(
     iter = 2
     nsteps = 1
     while sign_tstep * t0 < sign_tstep * tmax
-        δt = taylorstep!(Val(parse_eqs), f, t, x, abstol, params, rv, reltol)# δt is positive!
+        δt = taylorstep!(Val(parse_eqs), f, t, x, abstol, params, rv, reltol, minstep, maxstep)# δt is positive!
         # Below, δt has the proper sign according to the direction of the integration
         if iszero(δt)
             @warn("""The step-size is zero; aborting integration.""")
@@ -387,6 +399,8 @@ function taylorinteg(
     maxsteps::Int = 500,
     parse_eqs::Bool = true,
     reltol::T = zero(T),
+    minstep::T = zero(T),
+    maxstep::T = T(Inf)
 ) where {T<:Real,U<:Number}
 
     # Check if trange is increasingly or decreasingly sorted
@@ -395,7 +409,7 @@ function taylorinteg(
     # Allocation
     cache = init_cache(Val(false), trange, q0, maxsteps, order, f!, params; parse_eqs)
 
-    return taylorinteg!(f!, q0, trange, abstol, cache, params; maxsteps, reltol)
+    return taylorinteg!(f!, q0, trange, abstol, cache, params; maxsteps, reltol, minstep, maxstep)
 end
 
 function taylorinteg!(
@@ -407,6 +421,8 @@ function taylorinteg!(
     params;
     maxsteps::Int = 500,
     reltol::T = zero(T),
+    minstep::T = zero(T),
+    maxstep::T = T(Inf)
 ) where {T<:Real,U<:Number}
 
     (; xv, xaux, x0, x1, t, x, dx, rv, parse_eqs) = cache
@@ -422,7 +438,7 @@ function taylorinteg!(
     iter = 2
     nsteps = 1
     while sign_tstep * t0 < sign_tstep * tmax
-        δt = taylorstep!(Val(parse_eqs), f!, t, x, dx, xaux, abstol, params, rv, reltol) # δt is positive!
+        δt = taylorstep!(Val(parse_eqs), f!, t, x, dx, xaux, abstol, params, rv, reltol, minstep, maxstep) # δt is positive!
         if iszero(δt)
             @warn("""The step-size is zero; aborting integration.""")
             break
@@ -473,10 +489,12 @@ for R in (:Number, :Integer)
             maxsteps::Int = 500,
             parse_eqs::Bool = true,
             reltol::V = zero(V),
+            minstep::V = zero(V),
+            maxstep::V = V(Inf)
         ) where {S<:$R,T<:Real,U<:Real,V<:Real}
 
             # In order to handle mixed input types, we promote types before integrating:
-            t0, tmax, abstol, rreltol, _ = promote(tt0, ttmax, aabstol, reltol, one(Float64))
+            t0, tmax, abstol, rreltol, rminstep, rmaxstep, _ = promote(tt0, ttmax, aabstol, reltol, minstep, maxstep, one(Float64))
             x0, _ = promote(xx0, t0)
 
             return taylorinteg(
@@ -491,6 +509,8 @@ for R in (:Number, :Integer)
                 maxsteps = maxsteps,
                 parse_eqs = parse_eqs,
                 reltol = rreltol,
+                minstep = rminstep,
+                maxstep = rmaxstep
             )
         end
 
@@ -506,10 +526,12 @@ for R in (:Number, :Integer)
             maxsteps::Int = 500,
             parse_eqs::Bool = true,
             reltol::V = zero(V),
+            minstep::V = zero(V),
+            maxstep::V = V(Inf)
         ) where {S<:$R,T<:Real,U<:Real,V<:Real}
 
             #promote to common type before integrating:
-            t0, tmax, abstol, rreltol, _ = promote(tt0, ttmax, aabstol, reltol, one(Float64))
+            t0, tmax, abstol, rreltol, rminstep, rmaxstep, _ = promote(tt0, ttmax, aabstol, reltol, minstep, maxstep, one(Float64))
             elq0, _ = promote(q0[1], t0)
             #convert the elements of q0 to the common, promoted type:
             q0_ = convert(Array{typeof(elq0)}, q0)
@@ -526,6 +548,8 @@ for R in (:Number, :Integer)
                 maxsteps = maxsteps,
                 parse_eqs = parse_eqs,
                 reltol = rreltol,
+                minstep = rminstep,
+                maxstep = rmaxstep
             )
         end
 
@@ -539,9 +563,11 @@ for R in (:Number, :Integer)
             maxsteps::Int = 500,
             parse_eqs::Bool = true,
             reltol::U = zero(U),
+            minstep::U = zero(U),
+            maxstep::U = U(Inf)
         ) where {S<:$R,T<:Real,U<:Real}
 
-            t0, abstol, rreltol, _ = promote(trange[1], aabstol, reltol, one(Float64))
+            t0, abstol, rreltol, rminstep, rmaxstep, _ = promote(trange[1], aabstol, reltol, minstep, maxstep, one(Float64))
             x0, _ = promote(xx0, t0)
 
             return taylorinteg(
@@ -554,6 +580,8 @@ for R in (:Number, :Integer)
                 maxsteps = maxsteps,
                 parse_eqs = parse_eqs,
                 reltol = rreltol,
+                minstep = rminstep,
+                maxstep = rmaxstep
             )
         end
 
@@ -567,9 +595,11 @@ for R in (:Number, :Integer)
             maxsteps::Int = 500,
             parse_eqs::Bool = true,
             reltol::U = zero(U),
+            minstep::U = zero(U),
+            maxstep::U = U(Inf)
         ) where {S<:$R,T<:Real,U<:Real}
 
-            t0, abstol, rreltol, _ = promote(trange[1], aabstol, reltol, one(Float64))
+            t0, abstol, rreltol, rminstep, rmaxstep, _ = promote(trange[1], aabstol, reltol, minstep, maxstep, one(Float64))
             elq0, _ = promote(q0[1], t0)
             q0_ = convert(Array{typeof(elq0)}, q0)
 
@@ -583,6 +613,8 @@ for R in (:Number, :Integer)
                 maxsteps = maxsteps,
                 parse_eqs = parse_eqs,
                 reltol = rreltol,
+                minstep = rminstep,
+                maxstep = rmaxstep
             )
         end
 

--- a/src/integrator/taylorinteg.jl
+++ b/src/integrator/taylorinteg.jl
@@ -81,14 +81,15 @@ function taylorinteg(
     parse_eqs::Bool = true,
     dense::Bool = true,
     reltol::T = zero(T),
-    minstep::T = zero(T),
-    maxstep::T = T(Inf)
+    minstepsize::T = zero(T),
+    maxstepsize::T = T(Inf)
 ) where {T<:Real,U<:Number}
 
     # Allocation
     cache = init_cache(Val(dense), t0, x0, maxsteps, order, f, params; parse_eqs)
 
-    return taylorinteg!(Val(dense), f, x0, t0, tmax, abstol, cache, params; maxsteps, reltol, minstep, maxstep)
+    return taylorinteg!(Val(dense), f, x0, t0, tmax, abstol, cache, params; maxsteps,
+                        reltol, minstepsize, maxstepsize)
 end
 
 function taylorinteg!(
@@ -102,8 +103,8 @@ function taylorinteg!(
     params;
     maxsteps::Int = 500,
     reltol::T = zero(T),
-    minstep::T = zero(T),
-    maxstep::T = T(Inf)
+    minstepsize::T = zero(T),
+    maxstepsize::T = T(Inf)
 ) where {T<:Real,U<:Number,D}
 
     (; tv, xv, psol, t, x, rv, parse_eqs) = cache
@@ -117,7 +118,8 @@ function taylorinteg!(
 
     # Integration
     while sign_tstep * t0 < sign_tstep * tmax
-        δt = taylorstep!(Val(parse_eqs), f, t, x, abstol, params, rv, reltol, minstep, maxstep) # δt is positive!
+        δt = taylorstep!(Val(parse_eqs), f, t, x, abstol, params, rv, reltol,
+                         minstepsize, maxstepsize) # δt is positive!
         # Below, δt has the proper sign according to the direction of the integration
         if iszero(δt)
             @warn("""The step-size is zero; aborting integration.""")
@@ -155,14 +157,15 @@ function taylorinteg(
     parse_eqs::Bool = true,
     dense::Bool = true,
     reltol::T = zero(T),
-    minstep::T = zero(T),
-    maxstep::T = T(Inf)
+    minstepsize::T = zero(T),
+    maxstepsize::T = T(Inf)
 ) where {T<:Real,U<:Number}
 
     # Allocation
     cache = init_cache(Val(dense), t0, q0, maxsteps, order, f!, params; parse_eqs)
 
-    return taylorinteg!(Val(dense), f!, q0, t0, tmax, abstol, cache, params; maxsteps, reltol, minstep, maxstep)
+    return taylorinteg!(Val(dense), f!, q0, t0, tmax, abstol, cache, params; maxsteps,
+                        reltol, minstepsize, maxstepsize)
 end
 
 function taylorinteg!(
@@ -176,8 +179,8 @@ function taylorinteg!(
     params;
     maxsteps::Int = 500,
     reltol::T = zero(T),
-    minstep::T = zero(T),
-    maxstep::T = T(Inf)
+    minstepsize::T = zero(T),
+    maxstepsize::T = T(Inf)
 ) where {T<:Real,U<:Number,D}
 
     (; tv, xv, psol, xaux, t, x, dx, rv, parse_eqs) = cache
@@ -192,7 +195,8 @@ function taylorinteg!(
     # Integration
     nsteps = 1
     while sign_tstep * t0 < sign_tstep * tmax
-        δt = taylorstep!(Val(parse_eqs), f!, t, x, dx, xaux, abstol, params, rv, reltol, minstep, maxstep) # δt is positive!
+        δt = taylorstep!(Val(parse_eqs), f!, t, x, dx, xaux, abstol, params, rv, reltol,
+                         minstepsize, maxstepsize) # δt is positive!
         # Below, δt has the proper sign according to the direction of the integration
         if iszero(δt)
             @warn("""The step-size is zero; aborting integration.""")
@@ -318,8 +322,8 @@ function taylorinteg(
     maxsteps::Int = 500,
     parse_eqs::Bool = true,
     reltol::T = zero(T),
-    minstep::T = zero(T),
-    maxstep::T = T(Inf)
+    minstepsize::T = zero(T),
+    maxstepsize::T = T(Inf)
 ) where {T<:Real,U<:Number}
 
     # Check if trange is increasingly or decreasingly sorted
@@ -328,7 +332,8 @@ function taylorinteg(
     # Allocation
     cache = init_cache(Val(false), trange, x0, maxsteps, order, f, params; parse_eqs)
 
-    return taylorinteg!(f, x0, trange, abstol, cache, params; maxsteps, reltol, minstep, maxstep)
+    return taylorinteg!(f, x0, trange, abstol, cache, params; maxsteps, reltol,
+                        minstepsize, maxstepsize)
 end
 
 function taylorinteg!(
@@ -340,8 +345,8 @@ function taylorinteg!(
     params;
     maxsteps::Int = 500,
     reltol::T = zero(T),
-    minstep::T = zero(T),
-    maxstep::T = T(Inf)
+    minstepsize::T = zero(T),
+    maxstepsize::T = T(Inf)
 ) where {T<:Real,U<:Number}
 
     (; xv, t, x, rv, parse_eqs) = cache
@@ -356,7 +361,8 @@ function taylorinteg!(
     iter = 2
     nsteps = 1
     while sign_tstep * t0 < sign_tstep * tmax
-        δt = taylorstep!(Val(parse_eqs), f, t, x, abstol, params, rv, reltol, minstep, maxstep)# δt is positive!
+        δt = taylorstep!(Val(parse_eqs), f, t, x, abstol, params, rv, reltol,
+                         minstepsize, maxstepsize)# δt is positive!
         # Below, δt has the proper sign according to the direction of the integration
         if iszero(δt)
             @warn("""The step-size is zero; aborting integration.""")
@@ -399,8 +405,8 @@ function taylorinteg(
     maxsteps::Int = 500,
     parse_eqs::Bool = true,
     reltol::T = zero(T),
-    minstep::T = zero(T),
-    maxstep::T = T(Inf)
+    minstepsize::T = zero(T),
+    maxstepsize::T = T(Inf)
 ) where {T<:Real,U<:Number}
 
     # Check if trange is increasingly or decreasingly sorted
@@ -409,7 +415,8 @@ function taylorinteg(
     # Allocation
     cache = init_cache(Val(false), trange, q0, maxsteps, order, f!, params; parse_eqs)
 
-    return taylorinteg!(f!, q0, trange, abstol, cache, params; maxsteps, reltol, minstep, maxstep)
+    return taylorinteg!(f!, q0, trange, abstol, cache, params; maxsteps, reltol,
+                        minstepsize, maxstepsize)
 end
 
 function taylorinteg!(
@@ -421,8 +428,8 @@ function taylorinteg!(
     params;
     maxsteps::Int = 500,
     reltol::T = zero(T),
-    minstep::T = zero(T),
-    maxstep::T = T(Inf)
+    minstepsize::T = zero(T),
+    maxstepsize::T = T(Inf)
 ) where {T<:Real,U<:Number}
 
     (; xv, xaux, x0, x1, t, x, dx, rv, parse_eqs) = cache
@@ -438,7 +445,8 @@ function taylorinteg!(
     iter = 2
     nsteps = 1
     while sign_tstep * t0 < sign_tstep * tmax
-        δt = taylorstep!(Val(parse_eqs), f!, t, x, dx, xaux, abstol, params, rv, reltol, minstep, maxstep) # δt is positive!
+        δt = taylorstep!(Val(parse_eqs), f!, t, x, dx, xaux, abstol, params, rv, reltol,
+                         minstepsize, maxstepsize) # δt is positive!
         if iszero(δt)
             @warn("""The step-size is zero; aborting integration.""")
             break
@@ -489,12 +497,13 @@ for R in (:Number, :Integer)
             maxsteps::Int = 500,
             parse_eqs::Bool = true,
             reltol::V = zero(V),
-            minstep::V = zero(V),
-            maxstep::V = V(Inf)
+            minstepsize::V = zero(V),
+            maxstepsize::V = V(Inf)
         ) where {S<:$R,T<:Real,U<:Real,V<:Real}
 
             # In order to handle mixed input types, we promote types before integrating:
-            t0, tmax, abstol, rreltol, rminstep, rmaxstep, _ = promote(tt0, ttmax, aabstol, reltol, minstep, maxstep, one(Float64))
+            t0, tmax, abstol, rreltol, rminstepsize, rmaxstepsize, _ = promote(tt0, ttmax, aabstol,
+                reltol, minstepsize, maxstepsize, one(Float64))
             x0, _ = promote(xx0, t0)
 
             return taylorinteg(
@@ -509,8 +518,8 @@ for R in (:Number, :Integer)
                 maxsteps = maxsteps,
                 parse_eqs = parse_eqs,
                 reltol = rreltol,
-                minstep = rminstep,
-                maxstep = rmaxstep
+                minstepsize = rminstepsize,
+                maxstepsize = rmaxstepsize
             )
         end
 
@@ -526,12 +535,13 @@ for R in (:Number, :Integer)
             maxsteps::Int = 500,
             parse_eqs::Bool = true,
             reltol::V = zero(V),
-            minstep::V = zero(V),
-            maxstep::V = V(Inf)
+            minstepsize::V = zero(V),
+            maxstepsize::V = V(Inf)
         ) where {S<:$R,T<:Real,U<:Real,V<:Real}
 
             #promote to common type before integrating:
-            t0, tmax, abstol, rreltol, rminstep, rmaxstep, _ = promote(tt0, ttmax, aabstol, reltol, minstep, maxstep, one(Float64))
+            t0, tmax, abstol, rreltol, rminstepsize, rmaxstepsize, _ = promote(tt0, ttmax, aabstol,
+                reltol, minstepsize, maxstepsize, one(Float64))
             elq0, _ = promote(q0[1], t0)
             #convert the elements of q0 to the common, promoted type:
             q0_ = convert(Array{typeof(elq0)}, q0)
@@ -548,8 +558,8 @@ for R in (:Number, :Integer)
                 maxsteps = maxsteps,
                 parse_eqs = parse_eqs,
                 reltol = rreltol,
-                minstep = rminstep,
-                maxstep = rmaxstep
+                minstepsize = rminstepsize,
+                maxstepsize = rmaxstepsize
             )
         end
 
@@ -563,11 +573,12 @@ for R in (:Number, :Integer)
             maxsteps::Int = 500,
             parse_eqs::Bool = true,
             reltol::U = zero(U),
-            minstep::U = zero(U),
-            maxstep::U = U(Inf)
+            minstepsize::U = zero(U),
+            maxstepsize::U = U(Inf)
         ) where {S<:$R,T<:Real,U<:Real}
 
-            t0, abstol, rreltol, rminstep, rmaxstep, _ = promote(trange[1], aabstol, reltol, minstep, maxstep, one(Float64))
+            t0, abstol, rreltol, rminstepsize, rmaxstepsize, _ = promote(trange[1], aabstol,
+                reltol, minstepsize, maxstepsize, one(Float64))
             x0, _ = promote(xx0, t0)
 
             return taylorinteg(
@@ -580,8 +591,8 @@ for R in (:Number, :Integer)
                 maxsteps = maxsteps,
                 parse_eqs = parse_eqs,
                 reltol = rreltol,
-                minstep = rminstep,
-                maxstep = rmaxstep
+                minstepsize = rminstepsize,
+                maxstepsize = rmaxstepsize
             )
         end
 
@@ -595,11 +606,12 @@ for R in (:Number, :Integer)
             maxsteps::Int = 500,
             parse_eqs::Bool = true,
             reltol::U = zero(U),
-            minstep::U = zero(U),
-            maxstep::U = U(Inf)
+            minstepsize::U = zero(U),
+            maxstepsize::U = U(Inf)
         ) where {S<:$R,T<:Real,U<:Real}
 
-            t0, abstol, rreltol, rminstep, rmaxstep, _ = promote(trange[1], aabstol, reltol, minstep, maxstep, one(Float64))
+            t0, abstol, rreltol, rminstepsize, rmaxstepsize, _ = promote(trange[1], aabstol,
+                reltol, minstepsize, maxstepsize, one(Float64))
             elq0, _ = promote(q0[1], t0)
             q0_ = convert(Array{typeof(elq0)}, q0)
 
@@ -613,8 +625,8 @@ for R in (:Number, :Integer)
                 maxsteps = maxsteps,
                 parse_eqs = parse_eqs,
                 reltol = rreltol,
-                minstep = rminstep,
-                maxstep = rmaxstep
+                minstepsize = rminstepsize,
+                maxstepsize = rmaxstepsize
             )
         end
 

--- a/src/integrator/taylorstep.jl
+++ b/src/integrator/taylorstep.jl
@@ -38,14 +38,16 @@ function taylorstep!(
     abstol::T,
     params,
     rv::RetAlloc{Taylor1{U}},
-    reltol::T=zero(T),
+    reltol::T = zero(T),
+    minstep::T = zero(T),
+    maxstep::T = T(Inf)
 ) where {T<:Real,U<:Number,V}
 
     # Compute the Taylor coefficients
     __jetcoeffs!(Val(V), f, t, x, params, rv)
 
     # Compute the step-size of the integration using `abstol`
-    δt = stepsize(x, abstol, reltol)
+    δt = stepsize(x, abstol, reltol, minstep, maxstep)
     if isinf(δt)
         δt = _second_stepsize(x, abstol)
     end
@@ -63,14 +65,16 @@ function taylorstep!(
     abstol::T,
     params,
     rv::RetAlloc{Taylor1{U}},
-    reltol::T=zero(T),
+    reltol::T = zero(T),
+    minstep::T = zero(T),
+    maxstep::T = T(Inf)
 ) where {T<:Real,U<:Number,V}
 
     # Compute the Taylor coefficients
     __jetcoeffs!(Val(V), f!, t, x, dx, xaux, params, rv)
 
     # Compute the step-size of the integration using `abstol`
-    δt = stepsize(x, abstol, reltol)
+    δt = stepsize(x, abstol, reltol, minstep, maxstep)
 
     return δt
 end

--- a/src/integrator/taylorstep.jl
+++ b/src/integrator/taylorstep.jl
@@ -39,15 +39,15 @@ function taylorstep!(
     params,
     rv::RetAlloc{Taylor1{U}},
     reltol::T = zero(T),
-    minstep::T = zero(T),
-    maxstep::T = T(Inf)
+    minstepsize::T = zero(T),
+    maxstepsize::T = T(Inf)
 ) where {T<:Real,U<:Number,V}
 
     # Compute the Taylor coefficients
     __jetcoeffs!(Val(V), f, t, x, params, rv)
 
     # Compute the step-size of the integration using `abstol`
-    δt = stepsize(x, abstol, reltol, minstep, maxstep)
+    δt = stepsize(x, abstol, reltol, minstepsize, maxstepsize)
     if isinf(δt)
         δt = _second_stepsize(x, abstol)
     end
@@ -66,15 +66,15 @@ function taylorstep!(
     params,
     rv::RetAlloc{Taylor1{U}},
     reltol::T = zero(T),
-    minstep::T = zero(T),
-    maxstep::T = T(Inf)
+    minstepsize::T = zero(T),
+    maxstepsize::T = T(Inf)
 ) where {T<:Real,U<:Number,V}
 
     # Compute the Taylor coefficients
     __jetcoeffs!(Val(V), f!, t, x, dx, xaux, params, rv)
 
     # Compute the step-size of the integration using `abstol`
-    δt = stepsize(x, abstol, reltol, minstep, maxstep)
+    δt = stepsize(x, abstol, reltol, minstepsize, maxstepsize)
 
     return δt
 end

--- a/src/integrator/taylorstep.jl
+++ b/src/integrator/taylorstep.jl
@@ -47,10 +47,11 @@ function taylorstep!(
     __jetcoeffs!(Val(V), f, t, x, params, rv)
 
     # Compute the step-size of the integration using `abstol`
-    δt = stepsize(x, abstol, reltol, minstepsize, maxstepsize)
+    δt = stepsize(x, abstol, reltol)
     if isinf(δt)
         δt = _second_stepsize(x, abstol)
     end
+    δt = clamp(δt, minstepsize, maxstepsize)
 
     return δt
 end
@@ -74,7 +75,8 @@ function taylorstep!(
     __jetcoeffs!(Val(V), f!, t, x, dx, xaux, params, rv)
 
     # Compute the step-size of the integration using `abstol`
-    δt = stepsize(x, abstol, reltol, minstepsize, maxstepsize)
+    δt = stepsize(x, abstol, reltol)
+    δt = clamp(δt, minstepsize, maxstepsize)
 
     return δt
 end

--- a/src/lyapunovspectrum.jl
+++ b/src/lyapunovspectrum.jl
@@ -240,8 +240,8 @@ function lyap_taylorstep!(
     rv::RetAlloc{Taylor1{U}},
     (jacobianfunc!) = nothing,
     reltol::T = zero(T),
-    minstep::T = zero(T),
-    maxstep::T = T(Inf)
+    minstepsize::T = zero(T),
+    maxstepsize::T = T(Inf)
 ) where {T<:Real,U<:Number,V}
 
     # Dimensions of phase-space: dof
@@ -267,7 +267,7 @@ function lyap_taylorstep!(
     lyap_jetcoeffs!(t, view(x, dof+1:nx), view(dx, dof+1:nx), jac, varsaux)
 
     # Compute the step-size of the integration using `abstol`
-    δt = stepsize(view(x, 1:dof), abstol, reltol, minstep, maxstep)
+    δt = stepsize(view(x, 1:dof), abstol, reltol, minstepsize, maxstepsize)
 
     return δt
 end
@@ -301,8 +301,8 @@ function lyap_taylorinteg(
     maxsteps::Int = 500,
     parse_eqs::Bool = true,
     reltol::T = zero(T),
-    minstep::T = zero(T),
-    maxstep::T = T(Inf)
+    minstepsize::T = zero(T),
+    maxstepsize::T = T(Inf)
 ) where {T<:Real,U<:Number}
 
     dof = length(q0)
@@ -331,8 +331,8 @@ function lyap_taylorinteg(
         maxsteps,
         cache.parse_eqs,
         reltol,
-        minstep,
-        maxstep
+        minstepsize,
+        maxstepsize
     )
 end
 
@@ -349,8 +349,8 @@ function lyap_taylorinteg!(
     parse_eqs::Bool = true,
     maxsteps::Int = 500,
     reltol::T = zero(T),
-    minstep::T = zero(T),
-    maxstep::T = T(Inf)
+    minstepsize::T = zero(T),
+    maxstepsize::T = T(Inf)
 ) where {T<:Real,U<:Number}
 
     (; tv, xv, xaux, x0, λ, λtsum, δx, dδx, jac, varsaux,
@@ -393,8 +393,8 @@ function lyap_taylorinteg!(
             rv,
             jacobianfunc!,
             reltol,
-            minstep,
-            maxstep
+            minstepsize,
+            maxstepsize
         ) # δt is positive!
         # Below, δt has the proper sign according to the direction of the integration
         δt = sign_tstep * min(δt, sign_tstep * (tmax - t0))
@@ -439,8 +439,8 @@ function lyap_taylorinteg(
     maxsteps::Int = 500,
     parse_eqs::Bool = true,
     reltol::T = zero(T),
-    minstep::T = zero(T),
-    maxstep::T = T(Inf)
+    minstepsize::T = zero(T),
+    maxstepsize::T = T(Inf)
 ) where {T<:Real,U<:Number}
 
     dof = length(q0)
@@ -471,8 +471,8 @@ function lyap_taylorinteg(
         cache.parse_eqs,
         maxsteps,
         reltol,
-        minstep,
-        maxstep
+        minstepsize,
+        maxstepsize
     )
 
 end
@@ -489,8 +489,8 @@ function lyap_taylorinteg!(
     parse_eqs::Bool = true,
     maxsteps::Int = 500,
     reltol::T = zero(T),
-    minstep::T = zero(T),
-    maxstep::T = T(Inf)
+    minstepsize::T = zero(T),
+    maxstepsize::T = T(Inf)
 ) where {T<:Real,U<:Number}
 
     (; xv, xaux, x0, q1, λ, λtsum, δx, dδx, jac, varsaux,
@@ -534,8 +534,8 @@ function lyap_taylorinteg!(
             rv,
             jacobianfunc!,
             reltol,
-            minstep,
-            maxstep
+            minstepsize,
+            maxstepsize
         ) # δt is positive!
         # Below, δt has the proper sign according to the direction of the integration
         δt = sign_tstep * min(δt, sign_tstep * (tmax - t0))

--- a/src/lyapunovspectrum.jl
+++ b/src/lyapunovspectrum.jl
@@ -240,6 +240,8 @@ function lyap_taylorstep!(
     rv::RetAlloc{Taylor1{U}},
     (jacobianfunc!) = nothing,
     reltol::T = zero(T),
+    minstep::T = zero(T),
+    maxstep::T = T(Inf)
 ) where {T<:Real,U<:Number,V}
 
     # Dimensions of phase-space: dof
@@ -265,7 +267,7 @@ function lyap_taylorstep!(
     lyap_jetcoeffs!(t, view(x, dof+1:nx), view(dx, dof+1:nx), jac, varsaux)
 
     # Compute the step-size of the integration using `abstol`
-    δt = stepsize(view(x, 1:dof), abstol, reltol)
+    δt = stepsize(view(x, 1:dof), abstol, reltol, minstep, maxstep)
 
     return δt
 end
@@ -299,6 +301,8 @@ function lyap_taylorinteg(
     maxsteps::Int = 500,
     parse_eqs::Bool = true,
     reltol::T = zero(T),
+    minstep::T = zero(T),
+    maxstep::T = T(Inf)
 ) where {T<:Real,U<:Number}
 
     dof = length(q0)
@@ -327,6 +331,8 @@ function lyap_taylorinteg(
         maxsteps,
         cache.parse_eqs,
         reltol,
+        minstep,
+        maxstep
     )
 end
 
@@ -343,6 +349,8 @@ function lyap_taylorinteg!(
     parse_eqs::Bool = true,
     maxsteps::Int = 500,
     reltol::T = zero(T),
+    minstep::T = zero(T),
+    maxstep::T = T(Inf)
 ) where {T<:Real,U<:Number}
 
     (; tv, xv, xaux, x0, λ, λtsum, δx, dδx, jac, varsaux,
@@ -385,6 +393,8 @@ function lyap_taylorinteg!(
             rv,
             jacobianfunc!,
             reltol,
+            minstep,
+            maxstep
         ) # δt is positive!
         # Below, δt has the proper sign according to the direction of the integration
         δt = sign_tstep * min(δt, sign_tstep * (tmax - t0))
@@ -429,6 +439,8 @@ function lyap_taylorinteg(
     maxsteps::Int = 500,
     parse_eqs::Bool = true,
     reltol::T = zero(T),
+    minstep::T = zero(T),
+    maxstep::T = T(Inf)
 ) where {T<:Real,U<:Number}
 
     dof = length(q0)
@@ -459,6 +471,8 @@ function lyap_taylorinteg(
         cache.parse_eqs,
         maxsteps,
         reltol,
+        minstep,
+        maxstep
     )
 
 end
@@ -475,6 +489,8 @@ function lyap_taylorinteg!(
     parse_eqs::Bool = true,
     maxsteps::Int = 500,
     reltol::T = zero(T),
+    minstep::T = zero(T),
+    maxstep::T = T(Inf)
 ) where {T<:Real,U<:Number}
 
     (; xv, xaux, x0, q1, λ, λtsum, δx, dδx, jac, varsaux,
@@ -518,6 +534,8 @@ function lyap_taylorinteg!(
             rv,
             jacobianfunc!,
             reltol,
+            minstep,
+            maxstep
         ) # δt is positive!
         # Below, δt has the proper sign according to the direction of the integration
         δt = sign_tstep * min(δt, sign_tstep * (tmax - t0))

--- a/src/lyapunovspectrum.jl
+++ b/src/lyapunovspectrum.jl
@@ -267,7 +267,8 @@ function lyap_taylorstep!(
     lyap_jetcoeffs!(t, view(x, dof+1:nx), view(dx, dof+1:nx), jac, varsaux)
 
     # Compute the step-size of the integration using `abstol`
-    δt = stepsize(view(x, 1:dof), abstol, reltol, minstepsize, maxstepsize)
+    δt = stepsize(view(x, 1:dof), abstol, reltol)
+    δt = clamp(δt, minstepsize, maxstepsize)
 
     return δt
 end

--- a/src/rootfinding.jl
+++ b/src/rootfinding.jl
@@ -252,6 +252,8 @@ function taylorinteg(
     newtoniter::Int = 10,
     nrabstol::T = eps(T),
     reltol::T = zero(T),
+    minstep::T = zero(T),
+    maxstep::T = T(Inf)
 ) where {T<:Real,U<:Number}
 
     @assert order ≥ eventorder "`eventorder` must be less than or equal to `order`"
@@ -274,6 +276,8 @@ function taylorinteg(
         newtoniter,
         nrabstol,
         reltol,
+        minstep,
+        maxstep
     )
 end
 
@@ -292,6 +296,8 @@ function taylorinteg!(
     newtoniter::Int = 10,
     nrabstol::T = eps(T),
     reltol::T = zero(T),
+    minstep::T = zero(T),
+    maxstep::T = T(Inf)
 ) where {T<:Real,U<:Number,D}
 
     (; tv, xv, psol, xaux, t, x, dx, rv, parse_eqs) = cache
@@ -323,7 +329,7 @@ function taylorinteg!(
     nevents = 1 #number of detected events
     while sign_tstep * t0 < sign_tstep * tmax
         δt_old = δt
-        δt = taylorstep!(Val(parse_eqs), f!, t, x, dx, xaux, abstol, params, rv, reltol) # δt is positive!
+        δt = taylorstep!(Val(parse_eqs), f!, t, x, dx, xaux, abstol, params, rv, reltol, minstep, maxstep) # δt is positive!
         # Below, δt has the proper sign according to the direction of the integration
         δt = sign_tstep * min(δt, sign_tstep * (tmax - t0))
         evaluate!(x, δt, x0) # new initial condition
@@ -380,6 +386,8 @@ function taylorinteg(
     newtoniter::Int = 10,
     nrabstol::T = eps(T),
     reltol::T = zero(T),
+    minstep::T = zero(T),
+    maxstep::T = T(Inf)
 ) where {T<:Real,U<:Number}
 
     @assert order ≥ eventorder "`eventorder` must be less than or equal to `order`"
@@ -403,6 +411,8 @@ function taylorinteg(
         newtoniter,
         nrabstol,
         reltol,
+        minstep,
+        maxstep
     )
 end
 
@@ -419,6 +429,8 @@ function taylorinteg!(
     newtoniter::Int = 10,
     nrabstol::T = eps(T),
     reltol::T = zero(T),
+    minstep::T = zero(T),
+    maxstep::T = T(Inf)
 ) where {T<:Real,U<:Number}
 
     (; tv, xv, xaux, x0, x1, t, x, dx, rv, parse_eqs) = cache
@@ -451,7 +463,7 @@ function taylorinteg!(
     nevents = 1 #number of detected events
     while sign_tstep * t0 < sign_tstep * tmax
         δt_old = δt
-        δt = taylorstep!(Val(parse_eqs), f!, t, x, dx, xaux, abstol, params, rv, reltol) # δt is positive!
+        δt = taylorstep!(Val(parse_eqs), f!, t, x, dx, xaux, abstol, params, rv, reltol, minstep, maxstep) # δt is positive!
         # Below, δt has the proper sign according to the direction of the integration
         δt = sign_tstep * min(δt, sign_tstep * (tmax - t0))
         evaluate!(x, δt, x0) # new initial condition

--- a/src/rootfinding.jl
+++ b/src/rootfinding.jl
@@ -252,8 +252,8 @@ function taylorinteg(
     newtoniter::Int = 10,
     nrabstol::T = eps(T),
     reltol::T = zero(T),
-    minstep::T = zero(T),
-    maxstep::T = T(Inf)
+    minstepsize::T = zero(T),
+    maxstepsize::T = T(Inf)
 ) where {T<:Real,U<:Number}
 
     @assert order ≥ eventorder "`eventorder` must be less than or equal to `order`"
@@ -276,8 +276,8 @@ function taylorinteg(
         newtoniter,
         nrabstol,
         reltol,
-        minstep,
-        maxstep
+        minstepsize,
+        maxstepsize
     )
 end
 
@@ -296,8 +296,8 @@ function taylorinteg!(
     newtoniter::Int = 10,
     nrabstol::T = eps(T),
     reltol::T = zero(T),
-    minstep::T = zero(T),
-    maxstep::T = T(Inf)
+    minstepsize::T = zero(T),
+    maxstepsize::T = T(Inf)
 ) where {T<:Real,U<:Number,D}
 
     (; tv, xv, psol, xaux, t, x, dx, rv, parse_eqs) = cache
@@ -329,7 +329,8 @@ function taylorinteg!(
     nevents = 1 #number of detected events
     while sign_tstep * t0 < sign_tstep * tmax
         δt_old = δt
-        δt = taylorstep!(Val(parse_eqs), f!, t, x, dx, xaux, abstol, params, rv, reltol, minstep, maxstep) # δt is positive!
+        δt = taylorstep!(Val(parse_eqs), f!, t, x, dx, xaux, abstol, params, rv, reltol,
+                         minstepsize, maxstepsize) # δt is positive!
         # Below, δt has the proper sign according to the direction of the integration
         δt = sign_tstep * min(δt, sign_tstep * (tmax - t0))
         evaluate!(x, δt, x0) # new initial condition
@@ -386,8 +387,8 @@ function taylorinteg(
     newtoniter::Int = 10,
     nrabstol::T = eps(T),
     reltol::T = zero(T),
-    minstep::T = zero(T),
-    maxstep::T = T(Inf)
+    minstepsize::T = zero(T),
+    maxstepsize::T = T(Inf)
 ) where {T<:Real,U<:Number}
 
     @assert order ≥ eventorder "`eventorder` must be less than or equal to `order`"
@@ -411,8 +412,8 @@ function taylorinteg(
         newtoniter,
         nrabstol,
         reltol,
-        minstep,
-        maxstep
+        minstepsize,
+        maxstepsize
     )
 end
 
@@ -429,8 +430,8 @@ function taylorinteg!(
     newtoniter::Int = 10,
     nrabstol::T = eps(T),
     reltol::T = zero(T),
-    minstep::T = zero(T),
-    maxstep::T = T(Inf)
+    minstepsize::T = zero(T),
+    maxstepsize::T = T(Inf)
 ) where {T<:Real,U<:Number}
 
     (; tv, xv, xaux, x0, x1, t, x, dx, rv, parse_eqs) = cache
@@ -463,7 +464,8 @@ function taylorinteg!(
     nevents = 1 #number of detected events
     while sign_tstep * t0 < sign_tstep * tmax
         δt_old = δt
-        δt = taylorstep!(Val(parse_eqs), f!, t, x, dx, xaux, abstol, params, rv, reltol, minstep, maxstep) # δt is positive!
+        δt = taylorstep!(Val(parse_eqs), f!, t, x, dx, xaux, abstol, params, rv, reltol,
+                         minstepsize, maxstepsize) # δt is positive!
         # Below, δt has the proper sign according to the direction of the integration
         δt = sign_tstep * min(δt, sign_tstep * (tmax - t0))
         evaluate!(x, δt, x0) # new initial condition


### PR DESCRIPTION
This PR adds two new keywords to `taylorinteg` that give the user the possibility of clamping the integration step between a minimum and a maximum value.

Any comments @lbenet @PerezHz?