### PR TITLE
Throw error on no index found in `timeindex`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "TaylorIntegration"
 uuid = "92b13dbe-c966-51a2-8445-caca9f8a7d42"
-version = "0.18.9"
+version = "0.18.10"
 repo = "https://github.com/PerezHz/TaylorIntegration.jl.git"
 
 [deps]

--- a/src/integrator/taylorsolution.jl
+++ b/src/integrator/taylorsolution.jl
@@ -201,12 +201,22 @@ function timeindex(sol::TaylorSolution, t::TT) where {TT}
 
     @assert tmin ≤ _t ≤ tmax "Evaluation time outside range of interpolation"
 
+    if length(sol.t) == 1
+        return firstindex(sol.t)::Int, (t - t0)::TT
+    end
+
     if _t == sol.t[end]        # Compute solution at final time from last step expansion
         ind = lastindex(sol.t) - 1
     elseif issorted(sol.t)       # Forward integration
         ind = searchsortedlast(sol.t, _t)
     elseif issorted(sol.t, rev = true) # Backward integration
         ind = searchsortedlast(sol.t, _t, rev = true)
+    else
+        throw(
+            ArgumentError(
+                "`sol.t` must be sorted in increasing or decreasing order for interpolation.",
+            ),
+        )
     end
     # Time since the start of the ind-th timestep
     δt = t - sol.t[ind]
@@ -239,6 +249,7 @@ See also [`timeindex`](@ref).
 function (sol::TaylorSolution{T,U,1})(::Val{false}, t::T) where {T,U}
     # Get index of sol.x that interpolates at time t
     ind::Int, δt::T = timeindex(sol, t)
+    isempty(sol.p) && return sol.x[ind]::U
     # Evaluate sol.x[ind] at δt
     return (sol.p[ind])(δt)::U
 end
@@ -248,6 +259,7 @@ function (sol::TaylorSolution{T,U,1})(
 ) where {T,U,TT<:TaylorSolutionCallingArgs{T,U}}
     # Get index of sol.x that interpolates at time t
     ind::Int, δt::TT = timeindex(sol, t)
+    isempty(sol.p) && return (sol.x[ind] + zero(δt))::TT
     # Evaluate sol.x[ind] at δt
     return (sol.p[ind])(δt)::TT
 end
@@ -255,6 +267,7 @@ end
 function (sol::TaylorSolution{T,U,2})(::Val{false}, t::T) where {T,U}
     # Get index of sol.x that interpolates at time t
     ind::Int, δt::T = timeindex(sol, t)
+    isempty(sol.p) && return Vector(view(sol.x, ind, :))::Vector{U}
     # Evaluate sol.x[ind] at δt
     return view(sol.p, ind, :)(δt)::Vector{U}
 end
@@ -264,6 +277,7 @@ function (sol::TaylorSolution{T,U,2})(
 ) where {T,U,TT<:TaylorSolutionCallingArgs{T,U}}
     # Get index of sol.x that interpolates at time t
     ind::Int, δt::TT = timeindex(sol, t)
+    isempty(sol.p) && return [x + zero(δt) for x in view(sol.x, ind, :)]::Vector{TT}
     # Evaluate sol.x[ind] at δt
     return view(sol.p, ind, :)(δt)::Vector{TT}
 end

--- a/src/integrator/taylorsolution.jl
+++ b/src/integrator/taylorsolution.jl
@@ -277,7 +277,7 @@ function (sol::TaylorSolution{T,U,2})(
 ) where {T,U,TT<:TaylorSolutionCallingArgs{T,U}}
     # Get index of sol.x that interpolates at time t
     ind::Int, δt::TT = timeindex(sol, t)
-    isempty(sol.p) && return [x + zero(δt) for x in view(sol.x, ind, :)]::Vector{TT}
+    isempty(sol.p) && return (view(sol.x, ind, :) .+ zero(δt))::Vector{TT}
     # Evaluate sol.x[ind] at δt
     return view(sol.p, ind, :)(δt)::Vector{TT}
 end

--- a/test/solution.jl
+++ b/test/solution.jl
@@ -49,6 +49,14 @@ import Logging: Warn
     ind, δt = TaylorIntegration.timeindex(sol, t1)
     @test ind == 3
     @test δt == t1 - sol.t[ind]
+    sol_bad_time = TaylorSolution(
+        [0.0, 1.0, 2.0],
+        [0.0, 1.0, 2.0],
+        Taylor1.([0.0, 1.0], 1),
+    )
+    sol_bad_time.t[2] = -1.0
+    @test_throws ArgumentError TaylorIntegration.timeindex(sol_bad_time, 0.5)
+
     tv = collect((0:0.25:2) * pi)
     xv = Matrix(hcat(sin.(tv), cos.(tv))')
     psolv = Matrix(hcat(sin.(tv .+ Taylor1(25)), cos.(tv .+ Taylor1(25)))')
@@ -69,11 +77,18 @@ import Logging: Warn
 
     empty_p = Taylor1{Float64}[]
     @test (@inferred TaylorSolution([0.0], empty_p)).x == [0.0]
-    @test TaylorSolution([0.0], [1.0], empty_p).x == [1.0]
+    sol_empty = TaylorSolution([0.0], [1.0], empty_p)
+    @test sol_empty.x == [1.0]
+    ind_empty, δt_empty = TaylorIntegration.timeindex(sol_empty, 0.0)
+    @test ind_empty == 1
+    @test δt_empty == 0.0
+    @test sol_empty(0.0) == 1.0
 
     empty_matrix_p = Matrix{Taylor1{Float64}}(undef, 0, 2)
     @test (@inferred TaylorSolution([0.0], empty_matrix_p)).x == zeros(1, 2)
-    @test TaylorSolution([0.0], [1.0 2.0], empty_matrix_p).x == [1.0 2.0]
+    sol_empty_matrix = TaylorSolution([0.0], [1.0 2.0], empty_matrix_p)
+    @test sol_empty_matrix.x == [1.0 2.0]
+    @test sol_empty_matrix(0.0) == [1.0, 2.0]
 
     p_mismatched_endpoints = [
         Taylor1([1.0, 10.0], 1),


### PR DESCRIPTION
The way `TaylorSolution` works now this should not happen, since at construction the sortedness is checked for, but it's better anyway to add an `else` clause so that if no index is found a clear error is thrown, instead of a more obscure error.