### PR TITLE
Miscellaneous performance improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,3 +87,4 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel-finished: true
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,8 +62,6 @@ jobs:
             ${{ runner.os }}-test-${{ env.cache-name }}-
             ${{ runner.os }}-test-
             ${{ runner.os }}-
-      - name: Use TaylorSeries.jl PR #415 branch
-        run: julia --project=. -e 'using Pkg; Pkg.add(PackageSpec(url="https://github.com/PerezHz/TaylorSeries.jl", rev="jp/some-perf-fixes"))'
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,8 @@ jobs:
             ${{ runner.os }}-test-${{ env.cache-name }}-
             ${{ runner.os }}-test-
             ${{ runner.os }}-
+      - name: Use TaylorSeries.jl PR #415 branch
+        run: julia --project=. -e 'using Pkg; Pkg.add(PackageSpec(url="https://github.com/PerezHz/TaylorSeries.jl", rev="jp/some-perf-fixes"))'
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "TaylorIntegration"
 uuid = "92b13dbe-c966-51a2-8445-caca9f8a7d42"
-version = "0.18.13"
+version = "0.18.14"
 repo = "https://github.com/PerezHz/TaylorIntegration.jl.git"
 
 [deps]

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -16,11 +16,11 @@ BT.DEFAULT_PARAMETERS.samples = 25
 include("kepler_benchmarks.jl")
 include("manyspin_benchmarks.jl")
 include("Lyap_benchmark.jl")
+include("jettransport_benchmarks.jl")
 
 # ToDo:
 # pendulum
 # Lyapunov spectrum
-# jet transport
 # common interface
 # Poincare maps
 # @taylorize with @threads

--- a/benchmark/jettransport_benchmarks.jl
+++ b/benchmark/jettransport_benchmarks.jl
@@ -1,0 +1,61 @@
+# ==========
+# Jet transport dense output
+# ==========
+
+@taylorize function jt_pendulum!(dx, x, p, t)
+    dx[1] = x[2]
+    dx[2] = -sin(x[1])
+    return nothing
+end
+
+let
+    local _abstol = 1.0e-20
+    local _order = 20
+    local t0 = 0.0
+    local tf = 100.0
+    local maxsteps = 10_000
+    local q0 = [1.3, 0.0]
+
+    local q0T1 = [
+        Taylor1([q0[1], 1.0], 3),
+        Taylor1([q0[2], 1.0], 3),
+    ]
+
+    variables!("xi", numvars = 2, order = 3)
+    local q0TN = q0 + variables()
+
+    SUITE["JetTransport"] = BenchmarkGroup()
+
+    SUITE["JetTransport"]["Float64 dense"] = @benchmarkable taylorinteg(
+        jt_pendulum!,
+        $q0,
+        $t0,
+        $tf,
+        $_order,
+        $_abstol,
+        maxsteps = $maxsteps,
+        dense = true,
+    )
+
+    SUITE["JetTransport"]["Taylor1 dense"] = @benchmarkable taylorinteg(
+        jt_pendulum!,
+        $q0T1,
+        $t0,
+        $tf,
+        $_order,
+        $_abstol,
+        maxsteps = $maxsteps,
+        dense = true,
+    )
+
+    SUITE["JetTransport"]["TaylorN dense"] = @benchmarkable taylorinteg(
+        jt_pendulum!,
+        $q0TN,
+        $t0,
+        $tf,
+        $_order,
+        $_abstol,
+        maxsteps = $maxsteps,
+        dense = true,
+    )
+end

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -10,6 +10,7 @@ CurrentModule = TaylorIntegration
 
 ```@docs
 taylorinteg
+taylorinteg!
 lyap_taylorinteg
 @taylorize
 firsttime

--- a/src/integrator/stepsize.jl
+++ b/src/integrator/stepsize.jl
@@ -1,5 +1,34 @@
 # This file is part of the TaylorIntegration.jl package; MIT licensed
 
+@inline _norminf(x::Number) = norm(x, Inf)
+
+function _norminf(x::Taylor1)
+    coeffs = x.coeffs
+    @inbounds h = zero(_norminf(coeffs[firstindex(coeffs)]))
+    @inbounds for c in coeffs
+        h = max(h, _norminf(c))
+    end
+    return h
+end
+
+function _norminf(x::HomogeneousPolynomial)
+    coeffs = x.coeffs
+    @inbounds h = zero(_norminf(coeffs[firstindex(coeffs)]))
+    @inbounds for c in coeffs
+        h = max(h, _norminf(c))
+    end
+    return h
+end
+
+function _norminf(x::TaylorN)
+    coeffs = x.coeffs
+    @inbounds h = zero(_norminf(coeffs[firstindex(coeffs)]))
+    @inbounds for c in coeffs
+        h = max(h, _norminf(c))
+    end
+    return h
+end
+
 # stepsize
 """
     stepsize(x, epsilon) -> h
@@ -17,17 +46,18 @@ Depending of `eltype(x)`, i.e., `U<:Number`, it may be necessary to overload
 function stepsize(x::Taylor1{U}, absepsilon::T,
                   relepsilon::T = zero(T)) where {T<:Real,U<:Number}
     x0 = constant_term(x)
-    R = promote_type(typeof(norm(x0, Inf)), T)
+    x0norm = _norminf(x0)
+    R = promote_type(typeof(x0norm), T)
     ord = order(x)
     h = typemax(R)
     for k in (ord - 1, ord)
-        @inbounds aux = norm(x[k], Inf)
+        @inbounds aux = _norminf(x[k])
         TS._isthinzero(aux) && continue
         #eq. 3-3 Jorba and Zou (2005)
-        if absepsilon ≥ relepsilon * norm(x0, Inf)
+        if absepsilon ≥ relepsilon * x0norm
             aux1 = _stepsize(aux, absepsilon, k)
         else
-            aux1 = _stepsize(aux, relepsilon * norm(x0, Inf), k)
+            aux1 = _stepsize(aux, relepsilon * x0norm, k)
         end
         h = min(h, aux1)
     end
@@ -36,7 +66,7 @@ end
 
 function stepsize(q::AbstractArray{Taylor1{U},N}, absepsilon::T,
                   relepsilon::T = zero(T),) where {T<:Real,U<:Number,N}
-    R = promote_type(typeof(norm(constant_term(q[1]), Inf)), T)
+    R = promote_type(typeof(_norminf(constant_term(q[1]))), T)
     h = typemax(R)
     for i in eachindex(q)
         @inbounds hi = stepsize(q[i], absepsilon, relepsilon)
@@ -75,13 +105,13 @@ Corresponds to the "second stepsize control" in Jorba and Zou
 (2005) paper. We use it if [`stepsize`](@ref) returns `Inf`.
 """
 function _second_stepsize(x::Taylor1{U}, epsilon::T) where {T<:Real,U<:Number}
-    R = promote_type(typeof(norm(constant_term(x), Inf)), T)
+    R = promote_type(typeof(_norminf(constant_term(x))), T)
     TS._isthinzero(x) && return typemax(R)#convert(R, Inf)
     ord = order(x)
     u = one(R)
     h = zero(R)
     for k = 1:ord-2
-        @inbounds aux = norm(x[k], Inf)
+        @inbounds aux = _norminf(x[k])
         TS._isthinzero(aux) && continue
         aux1 = _stepsize(aux, u, k)
         h = max(h, aux1)

--- a/src/integrator/stepsize.jl
+++ b/src/integrator/stepsize.jl
@@ -1,5 +1,17 @@
 # This file is part of the TaylorIntegration.jl package; MIT licensed
 
+"""
+    _norminf(x::Number)
+    _norminf(x::Taylor1)
+    _norminf(x::HomogeneousPolynomial)
+    _norminf(x::TaylorN)
+
+Return the infinity norm used by the time-step controllers.
+
+For ordinary numbers this delegates to `norm(x, Inf)`. For nested Taylor
+objects, it recursively takes the maximum infinity norm over all stored
+coefficients, reducing values such as `Taylor1{TaylorN}` to a scalar norm.
+"""
 @inline _norminf(x::Number) = norm(x, Inf)
 
 function _norminf(x::Taylor1)

--- a/src/integrator/taylorinteg.jl
+++ b/src/integrator/taylorinteg.jl
@@ -1,5 +1,32 @@
 # This file is part of the TaylorIntegration.jl package; MIT licensed
 
+# _store_taylor!
+@inline function _stored_taylor(x::Taylor1{U}) where {U<:Number}
+    y = zero(x)
+    TS.identity!(y, x)
+    return y
+end
+
+@inline function _store_taylor!(psol::Array{Taylor1{U},1}, nsteps::Int,
+        x::Taylor1{U}) where {U<:Number}
+    if isassigned(psol, nsteps)
+        @inbounds TS.identity!(psol[nsteps], x)
+    else
+        @inbounds psol[nsteps] = _stored_taylor(x)
+    end
+    return nothing
+end
+
+@inline function _store_taylor!(psol::Array{Taylor1{U},2}, j::Int, nsteps::Int,
+        x::Taylor1{U}) where {U<:Number}
+    if isassigned(psol, j, nsteps)
+        @inbounds TS.identity!(psol[j, nsteps], x)
+    else
+        @inbounds psol[j, nsteps] = _stored_taylor(x)
+    end
+    return nothing
+end
+
 # set_psol!
 @doc doc"""
     set_psol!(::Val{true}, psol::Array{Taylor1{U},1}, nsteps::Int, x::Taylor1{U}) where {U<:Number}
@@ -19,7 +46,7 @@ field `:p` in [`TaylorSolution`](@ref). See also [`init_psol`](@ref).
     nsteps::Int,
     x::Taylor1{U},
 ) where {U<:Number}
-    @inbounds psol[nsteps] = deepcopy(x)
+    _store_taylor!(psol, nsteps, x)
     return nothing
 end
 @inline function set_psol!(
@@ -28,7 +55,9 @@ end
     nsteps::Int,
     x::Vector{Taylor1{U}},
 ) where {U<:Number}
-    @inbounds psol[:, nsteps] .= deepcopy.(x)
+    @inbounds for j in eachindex(x)
+        _store_taylor!(psol, j, nsteps, x[j])
+    end
     return nothing
 end
 @inline set_psol!(::Val{false}, args...) = nothing

--- a/src/integrator/taylorinteg.jl
+++ b/src/integrator/taylorinteg.jl
@@ -40,7 +40,18 @@ Matching `Taylor1` and `TaylorN` values with compatible lengths are updated in
 place with `TaylorSeries.identity!`, preserving the object already held by the
 cache. If the Taylor polynomial storage is incompatible, or if the value is an
 immutable scalar-like number, the method returns a fresh [`_stored_value`](@ref)
-instead. Callers must assign the return value back into the storage slot.
+instead.
+
+The return value is the object that should be stored. In the compatible Taylor
+case this is `dest` itself after mutation. In replacement cases this method
+cannot update the caller's array slot because it receives only the slot value,
+not the containing array and index. Therefore, when a new object is allocated,
+callers must assign the return value back into the storage slot, e.g.:
+
+```
+xv[i, nsteps] = _copy_value!(xv[i, nsteps], x0[i])
+```
+
 """
 @inline function _copy_value!(dest::Taylor1{U}, src::Taylor1{U}) where {U<:Number}
     length(dest) == length(src) || return _stored_value(src)

--- a/src/integrator/taylorinteg.jl
+++ b/src/integrator/taylorinteg.jl
@@ -40,18 +40,8 @@ Matching `Taylor1` and `TaylorN` values with compatible lengths are updated in
 place with `TaylorSeries.identity!`, preserving the object already held by the
 cache. If the Taylor polynomial storage is incompatible, or if the value is an
 immutable scalar-like number, the method returns a fresh [`_stored_value`](@ref)
-instead.
-
-The return value is the object that should be stored. In the compatible Taylor
-case this is `dest` itself after mutation. In replacement cases this method
-cannot update the caller's array slot because it receives only the slot value,
-not the containing array and index. Therefore, when a new object is allocated,
-callers must assign the return value back into the storage slot, e.g.:
-
-```
-xv[i, nsteps] = _copy_value!(xv[i, nsteps], x0[i])
-```
-
+instead. Use [`_store_value!`](@ref) when the caller has an array slot that can
+be updated directly.
 """
 @inline function _copy_value!(dest::Taylor1{U}, src::Taylor1{U}) where {U<:Number}
     length(dest) == length(src) || return _stored_value(src)
@@ -68,6 +58,36 @@ end
 @inline _copy_value!(dest::T, src::T) where {T<:Number} = _stored_value(src)
 
 """
+    _store_value!(dest::AbstractVector{U}, src::U, i) where {U<:Number}
+    _store_value!(dest::AbstractMatrix{U}, src::U, i, j) where {U<:Number}
+
+Store `src` in `dest[i]` or `dest[i, j]`, reusing an already assigned mutable
+Taylor slot when possible.
+
+This is the slot-aware wrapper around [`_copy_value!`](@ref). If the element
+type is `isbits` or the slot has not been assigned yet, a fresh
+[`_stored_value`](@ref) is assigned. Otherwise, the existing slot value is
+updated in place when possible, and replaced only when necessary.
+"""
+@inline function _store_value!(dest::AbstractVector{U}, src::U, i) where {U<:Number}
+    if Base.isbitstype(U) || !isassigned(dest, i)
+        @inbounds dest[i] = _stored_value(src)
+    else
+        @inbounds dest[i] = _copy_value!(dest[i], src)
+    end
+    return nothing
+end
+
+@inline function _store_value!(dest::AbstractMatrix{U}, src::U, i, j) where {U<:Number}
+    if Base.isbitstype(U) || !isassigned(dest, i, j)
+        @inbounds dest[i, j] = _stored_value(src)
+    else
+        @inbounds dest[i, j] = _copy_value!(dest[i, j], src)
+    end
+    return nothing
+end
+
+"""
     _stored_state(q0::AbstractVector{U}) where {U<:Number}
 
 Return a freshly allocated state vector whose entries are independent stored
@@ -80,7 +100,7 @@ or later cache mutations.
 function _stored_state(q0::AbstractVector{U}) where {U<:Number}
     x0 = similar(q0)
     @inbounds for i in eachindex(q0)
-        x0[i] = _stored_value(q0[i])
+        _store_value!(x0, q0[i], i)
     end
     return x0
 end
@@ -88,16 +108,15 @@ end
 """
     _copy_state!(dest::AbstractVector{U}, src::AbstractVector{U}) where {U<:Number}
 
-Copy `src` into the reusable state vector `dest`, updating compatible Taylor
-entries in place and replacing entries when in-place reuse is not possible.
+Copy `src` into the reusable state vector `dest`.
 
-Each element is copied through [`_copy_value!`](@ref), so the returned `dest`
-remains suitable as cache-owned working storage even when the element type is a
-mutable Taylor polynomial.
+Each element is stored through [`_store_value!`](@ref), so compatible Taylor
+entries are updated in place and incompatible or scalar entries are replaced in
+the vector slot.
 """
 function _copy_state!(dest::AbstractVector{U}, src::AbstractVector{U}) where {U<:Number}
     @inbounds for i in eachindex(src)
-        dest[i] = _copy_value!(dest[i], src[i])
+        _store_value!(dest, src[i], i)
     end
     return dest
 end
@@ -116,57 +135,12 @@ allocating new Taylor polynomial objects for every stored state.
 The integrator stores vector-valued states internally as `variables x steps`.
 For immutable `isbits` element types, values are assigned directly. For mutable
 Taylor-valued states, unassigned slots receive independent stored copies and
-assigned slots are updated in place through [`_copy_value!`](@ref).
+assigned slots are updated in place through [`_store_value!`](@ref).
 """
 function _store_state_column!(xv::AbstractMatrix{U}, nsteps::Int,
         x0::AbstractVector{U}) where {U<:Number}
     @inbounds for i in eachindex(x0)
-        if Base.isbitstype(U) || !isassigned(xv, i, nsteps)
-            xv[i, nsteps] = _stored_value(x0[i])
-        else
-            xv[i, nsteps] = _copy_value!(xv[i, nsteps], x0[i])
-        end
-    end
-    return nothing
-end
-
-"""
-    _store_taylor!(
-        psol::Array{Taylor1{U},1},
-        nsteps::Int,
-        x::Taylor1{U},
-    ) where {U<:Number}
-    _store_taylor!(
-        psol::Array{Taylor1{U},2},
-        j::Int,
-        nsteps::Int,
-        x::Taylor1{U},
-    ) where {U<:Number}
-
-Store the Taylor polynomial `x` in the dense-output cache `psol`. If the target
-slot is already assigned, the existing polynomial is updated in place with
-`TaylorSeries.identity!`; otherwise a new independent polynomial is stored.
-
-The one-dimensional method is used for scalar integrations. The two-dimensional
-method is used for vector integrations, where row `j` stores component `j` and
-column `nsteps` stores the dense polynomial for the current step.
-"""
-@inline function _store_taylor!(psol::Array{Taylor1{U},1}, nsteps::Int,
-        x::Taylor1{U}) where {U<:Number}
-    if isassigned(psol, nsteps)
-        @inbounds TS.identity!(psol[nsteps], x)
-    else
-        @inbounds psol[nsteps] = _stored_value(x)
-    end
-    return nothing
-end
-
-@inline function _store_taylor!(psol::Array{Taylor1{U},2}, j::Int, nsteps::Int,
-        x::Taylor1{U}) where {U<:Number}
-    if isassigned(psol, j, nsteps)
-        @inbounds TS.identity!(psol[j, nsteps], x)
-    else
-        @inbounds psol[j, nsteps] = _stored_value(x)
+        _store_value!(xv, x0[i], i, nsteps)
     end
     return nothing
 end
@@ -183,7 +157,7 @@ When the first argument is `Val(true)`, the method stores the current working
 Taylor polynomial(s) into `psol`, the dense-output cache backing field `:p` in
 [`TaylorSolution`](@ref). Scalar integrations store one polynomial per step;
 vector integrations store one polynomial per component and step. Assigned
-`psol` slots are reused in place through [`_store_taylor!`](@ref), so repeated
+`psol` slots are reused in place through [`_store_value!`](@ref), so repeated
 uses of a preallocated cache do not allocate fresh dense polynomials for every
 stored step. When the first argument is `Val(false)`, the method returns
 `nothing`.
@@ -196,7 +170,7 @@ See also [`init_psol`](@ref).
     nsteps::Int,
     x::Taylor1{U},
 ) where {U<:Number}
-    _store_taylor!(psol, nsteps, x)
+    _store_value!(psol, x, nsteps)
     return nothing
 end
 @inline function set_psol!(
@@ -206,7 +180,7 @@ end
     x::Vector{Taylor1{U}},
 ) where {U<:Number}
     @inbounds for j in eachindex(x)
-        _store_taylor!(psol, j, nsteps, x[j])
+        _store_value!(psol, x[j], j, nsteps)
     end
     return nothing
 end

--- a/src/integrator/taylorinteg.jl
+++ b/src/integrator/taylorinteg.jl
@@ -1,12 +1,16 @@
 # This file is part of the TaylorIntegration.jl package; MIT licensed
 
 """
-    _stored_taylor(x::Taylor1)
-    _stored_taylor(x::TaylorN)
+    _stored_taylor(x::Taylor1{U}) where {U<:Number}
+    _stored_taylor(x::TaylorN{U}) where {U<:Number}
 
 Return an independent Taylor polynomial with the same coefficients as `x`.
-This is used for storing `TaylorSolution` variables independently without relying on
-`deepcopy`.
+
+The returned object has fresh coefficient storage and is safe to keep in an
+integration cache, dense-output cache, or returned [`TaylorSolution`](@ref) even
+if the working Taylor polynomial `x` is mutated by later integration steps.
+This is the Taylor-specific replacement for `deepcopy` used by the storage
+helpers below.
 """
 @inline function _stored_taylor(x::Taylor1{U}) where {U<:Number}
     y = zero(x)
@@ -21,11 +25,16 @@ end
 end
 
 """
-    _stored_value(x)
+    _stored_value(x::Taylor1)
+    _stored_value(x::TaylorN)
+    _stored_value(x::T) where {T<:Number}
 
-Return a value suitable for storing in solution or cache arrays. Taylor
-polynomials are copied with [`_stored_taylor`](@ref), `isbits` variables are stored
-directly, and other `Number` subtypes fall back to `deepcopy`.
+Return a value suitable for storage in solution arrays and integration caches.
+
+Taylor polynomials are copied with [`_stored_taylor`](@ref), `isbits` numbers
+are stored directly, and other `Number` subtypes fall back to `deepcopy`. This
+gives mutable number-like values snapshot semantics while avoiding unnecessary
+copies for immutable scalar values.
 """
 @inline _stored_value(x::Taylor1) = _stored_taylor(x)
 @inline _stored_value(x::TaylorN) = _stored_taylor(x)
@@ -33,12 +42,18 @@ directly, and other `Number` subtypes fall back to `deepcopy`.
     Base.isbitstype(T) ? x : deepcopy(x)
 
 """
-    _copy_value!(dest, src)
+    _copy_value!(dest::Taylor1{U}, src::Taylor1{U}) where {U<:Number}
+    _copy_value!(dest::TaylorN{U}, src::TaylorN{U}) where {U<:Number}
+    _copy_value!(dest::T, src::T) where {T<:Number}
 
 Copy `src` into reusable storage `dest` when possible and return the stored
-value. Matching `Taylor1` and `TaylorN` values are updated with
-`TaylorSeries.identity!`; incompatible or immutable values are replaced by a
-fresh stored value.
+value.
+
+Matching `Taylor1` and `TaylorN` values with compatible lengths are updated in
+place with `TaylorSeries.identity!`, preserving the object already held by the
+cache. If the Taylor polynomial storage is incompatible, or if the value is an
+immutable scalar-like number, the method returns a fresh [`_stored_value`](@ref)
+instead. Callers must assign the return value back into the storage slot.
 """
 @inline function _copy_value!(dest::Taylor1{U}, src::Taylor1{U}) where {U<:Number}
     length(dest) == length(src) || return _stored_value(src)
@@ -55,10 +70,14 @@ end
 @inline _copy_value!(dest::T, src::T) where {T<:Number} = _stored_value(src)
 
 """
-    _stored_state(q0)
+    _stored_state(q0::AbstractVector{U}) where {U<:Number}
 
 Return a freshly allocated state vector whose entries are independent stored
 values copied from `q0`.
+
+This is used for working initial conditions that may contain mutable Taylor
+polynomials. It preserves the values from `q0` without aliasing the user's input
+or later cache mutations.
 """
 function _stored_state(q0::AbstractVector{U}) where {U<:Number}
     x0 = similar(q0)
@@ -69,10 +88,14 @@ function _stored_state(q0::AbstractVector{U}) where {U<:Number}
 end
 
 """
-    _copy_state!(dest, src)
+    _copy_state!(dest::AbstractVector{U}, src::AbstractVector{U}) where {U<:Number}
 
 Copy `src` into the reusable state vector `dest`, updating compatible Taylor
 entries in place and replacing entries when in-place reuse is not possible.
+
+Each element is copied through [`_copy_value!`](@ref), so the returned `dest`
+remains suitable as cache-owned working storage even when the element type is a
+mutable Taylor polynomial.
 """
 function _copy_state!(dest::AbstractVector{U}, src::AbstractVector{U}) where {U<:Number}
     @inbounds for i in eachindex(src)
@@ -82,11 +105,20 @@ function _copy_state!(dest::AbstractVector{U}, src::AbstractVector{U}) where {U<
 end
 
 """
-    _store_state_column!(xv, nsteps, x0)
+    _store_state_column!(
+        xv::AbstractMatrix{U},
+        nsteps::Int,
+        x0::AbstractVector{U},
+    ) where {U<:Number}
 
 Store the state vector `x0` in column `nsteps` of `xv`. Previously assigned
 non-isbits entries are reused when possible, so cache reuse does not require
 allocating new Taylor polynomial objects for every stored state.
+
+The integrator stores vector-valued states internally as `variables x steps`.
+For immutable `isbits` element types, values are assigned directly. For mutable
+Taylor-valued states, unassigned slots receive independent stored copies and
+assigned slots are updated in place through [`_copy_value!`](@ref).
 """
 function _store_state_column!(xv::AbstractMatrix{U}, nsteps::Int,
         x0::AbstractVector{U}) where {U<:Number}
@@ -101,12 +133,25 @@ function _store_state_column!(xv::AbstractMatrix{U}, nsteps::Int,
 end
 
 """
-    _store_taylor!(psol::Array{Taylor1{U},1}, nsteps::Int, x::Taylor1{U})
-    _store_taylor!(psol::Array{Taylor1{U},2}, j::Int, nsteps::Int, x::Taylor1{U})
+    _store_taylor!(
+        psol::Array{Taylor1{U},1},
+        nsteps::Int,
+        x::Taylor1{U},
+    ) where {U<:Number}
+    _store_taylor!(
+        psol::Array{Taylor1{U},2},
+        j::Int,
+        nsteps::Int,
+        x::Taylor1{U},
+    ) where {U<:Number}
 
 Store the Taylor polynomial `x` in the dense-output cache `psol`. If the target
 slot is already assigned, the existing polynomial is updated in place with
 `TaylorSeries.identity!`; otherwise a new independent polynomial is stored.
+
+The one-dimensional method is used for scalar integrations. The two-dimensional
+method is used for vector integrations, where row `j` stores component `j` and
+column `nsteps` stores the dense polynomial for the current step.
 """
 @inline function _store_taylor!(psol::Array{Taylor1{U},1}, nsteps::Int,
         x::Taylor1{U}) where {U<:Number}
@@ -134,12 +179,17 @@ end
     set_psol!(::Val{true}, psol::Array{Taylor1{U},2}, nsteps::Int, x::Vector{Taylor1{U}}) where {U<:Number}
     set_psol!(::Val{false}, args...)
 
-Auxiliary function to save Taylor polynomials in a call to [`taylorinteg`](@ref). When the
-first argument in the call signature is `Val(true)`, sets appropriate elements of argument
-`psol`. Otherwise, when the first argument in the call signature is `Val(false)`, this
-function simply returns `nothing`. Argument `psol` is the array
-where the Taylor polynomials associated to the solution will be stored, corresponding to
-field `:p` in [`TaylorSolution`](@ref). Assigned `psol` slots are reused in place.
+Auxiliary function to save Taylor polynomials in a call to [`taylorinteg`](@ref).
+
+When the first argument is `Val(true)`, the method stores the current working
+Taylor polynomial(s) into `psol`, the dense-output cache backing field `:p` in
+[`TaylorSolution`](@ref). Scalar integrations store one polynomial per step;
+vector integrations store one polynomial per component and step. Assigned
+`psol` slots are reused in place through [`_store_taylor!`](@ref), so repeated
+uses of a preallocated cache do not allocate fresh dense polynomials for every
+stored step. When the first argument is `Val(false)`, the method returns
+`nothing`.
+
 See also [`init_psol`](@ref).
 """
 @inline function set_psol!(
@@ -171,12 +221,16 @@ end
     init_psol(::Val{false}, ::Int, ::Int, ::Taylor1{U}) where {U<:Number}
     init_psol(::Val{false}, ::Int, ::Int, ::Array{Taylor1{U},1}) where {U<:Number}
 
-Auxiliary function to initialize `psol` during a call to [`taylorinteg`](@ref). When the
-first argument in the call signature is `Val(false)` this function simply returns `nothing`.
-Otherwise, when the first argument in the call signature is `Val(true)`, then the
-appropriate array is allocated and returned; this array is where the Taylor polynomials
-associated to the solution will be stored, corresponding to field `:p` in
-[`TaylorSolution`](@ref).
+Auxiliary function to initialize the dense-output storage `psol` during a call
+to [`taylorinteg`](@ref).
+
+When the first argument is `Val(true)`, the method allocates the array that will
+store Taylor polynomials for dense output and later become field `:p` in
+[`TaylorSolution`](@ref). Scalar integrations use a vector of length
+`maxsteps`; vector integrations use a `dof x maxsteps` matrix. The storage is
+left uninitialized so [`set_psol!`](@ref) can populate only the steps that are
+actually taken. When the first argument is `Val(false)`, the method returns
+`nothing`.
 """
 @inline function init_psol(
     ::Val{true},

--- a/src/integrator/taylorinteg.jl
+++ b/src/integrator/taylorinteg.jl
@@ -61,21 +61,13 @@ end
 
 @inline function _store_taylor!(psol::Array{Taylor1{U},1}, nsteps::Int,
         x::Taylor1{U}) where {U<:Number}
-    if isassigned(psol, nsteps)
-        @inbounds TS.identity!(psol[nsteps], x)
-    else
-        @inbounds psol[nsteps] = _stored_taylor(x)
-    end
+    @inbounds psol[nsteps] = _stored_taylor(x)
     return nothing
 end
 
 @inline function _store_taylor!(psol::Array{Taylor1{U},2}, j::Int, nsteps::Int,
         x::Taylor1{U}) where {U<:Number}
-    if isassigned(psol, j, nsteps)
-        @inbounds TS.identity!(psol[j, nsteps], x)
-    else
-        @inbounds psol[j, nsteps] = _stored_taylor(x)
-    end
+    @inbounds psol[j, nsteps] = _stored_taylor(x)
     return nothing
 end
 

--- a/src/integrator/taylorinteg.jl
+++ b/src/integrator/taylorinteg.jl
@@ -1,6 +1,13 @@
 # This file is part of the TaylorIntegration.jl package; MIT licensed
 
-# _store_taylor!
+"""
+    _stored_taylor(x::Taylor1)
+    _stored_taylor(x::TaylorN)
+
+Return an independent Taylor polynomial with the same coefficients as `x`.
+This is used for storing `TaylorSolution` variables independently without relying on
+`deepcopy`.
+"""
 @inline function _stored_taylor(x::Taylor1{U}) where {U<:Number}
     y = zero(x)
     TS.identity!(y, x)
@@ -13,11 +20,26 @@ end
     return y
 end
 
+"""
+    _stored_value(x)
+
+Return a value suitable for storing in solution or cache arrays. Taylor
+polynomials are copied with [`_stored_taylor`](@ref), `isbits` variables are stored
+directly, and other `Number` subtypes fall back to `deepcopy`.
+"""
 @inline _stored_value(x::Taylor1) = _stored_taylor(x)
 @inline _stored_value(x::TaylorN) = _stored_taylor(x)
 @inline _stored_value(x::T) where {T<:Number} =
     Base.isbitstype(T) ? x : deepcopy(x)
 
+"""
+    _copy_value!(dest, src)
+
+Copy `src` into reusable storage `dest` when possible and return the stored
+value. Matching `Taylor1` and `TaylorN` values are updated with
+`TaylorSeries.identity!`; incompatible or immutable values are replaced by a
+fresh stored value.
+"""
 @inline function _copy_value!(dest::Taylor1{U}, src::Taylor1{U}) where {U<:Number}
     length(dest) == length(src) || return _stored_value(src)
     TS.identity!(dest, src)
@@ -32,6 +54,12 @@ end
 
 @inline _copy_value!(dest::T, src::T) where {T<:Number} = _stored_value(src)
 
+"""
+    _stored_state(q0)
+
+Return a freshly allocated state vector whose entries are independent stored
+values copied from `q0`.
+"""
 function _stored_state(q0::AbstractVector{U}) where {U<:Number}
     x0 = similar(q0)
     @inbounds for i in eachindex(q0)
@@ -40,6 +68,12 @@ function _stored_state(q0::AbstractVector{U}) where {U<:Number}
     return x0
 end
 
+"""
+    _copy_state!(dest, src)
+
+Copy `src` into the reusable state vector `dest`, updating compatible Taylor
+entries in place and replacing entries when in-place reuse is not possible.
+"""
 function _copy_state!(dest::AbstractVector{U}, src::AbstractVector{U}) where {U<:Number}
     @inbounds for i in eachindex(src)
         dest[i] = _copy_value!(dest[i], src[i])
@@ -47,6 +81,13 @@ function _copy_state!(dest::AbstractVector{U}, src::AbstractVector{U}) where {U<
     return dest
 end
 
+"""
+    _store_state_column!(xv, nsteps, x0)
+
+Store the state vector `x0` in column `nsteps` of `xv`. Previously assigned
+non-isbits entries are reused when possible, so cache reuse does not require
+allocating new Taylor polynomial objects for every stored state.
+"""
 function _store_state_column!(xv::AbstractMatrix{U}, nsteps::Int,
         x0::AbstractVector{U}) where {U<:Number}
     @inbounds for i in eachindex(x0)
@@ -59,6 +100,14 @@ function _store_state_column!(xv::AbstractMatrix{U}, nsteps::Int,
     return nothing
 end
 
+"""
+    _store_taylor!(psol::Array{Taylor1{U},1}, nsteps::Int, x::Taylor1{U})
+    _store_taylor!(psol::Array{Taylor1{U},2}, j::Int, nsteps::Int, x::Taylor1{U})
+
+Store the Taylor polynomial `x` in the dense-output cache `psol`. If the target
+slot is already assigned, the existing polynomial is updated in place with
+`TaylorSeries.identity!`; otherwise a new independent polynomial is stored.
+"""
 @inline function _store_taylor!(psol::Array{Taylor1{U},1}, nsteps::Int,
         x::Taylor1{U}) where {U<:Number}
     if isassigned(psol, nsteps)
@@ -90,7 +139,8 @@ first argument in the call signature is `Val(true)`, sets appropriate elements o
 `psol`. Otherwise, when the first argument in the call signature is `Val(false)`, this
 function simply returns `nothing`. Argument `psol` is the array
 where the Taylor polynomials associated to the solution will be stored, corresponding to
-field `:p` in [`TaylorSolution`](@ref). See also [`init_psol`](@ref).
+field `:p` in [`TaylorSolution`](@ref). Assigned `psol` slots are reused in place.
+See also [`init_psol`](@ref).
 """
 @inline function set_psol!(
     ::Val{true},
@@ -173,6 +223,28 @@ function taylorinteg(
                         reltol, minstepsize, maxstepsize, copy_solution=Val(false))
 end
 
+"""
+    taylorinteg!(dense::Val, f, x0, t0, tmax, abstol, cache, params; kwargs...)
+    taylorinteg!(dense::Val, f!, q0, t0, tmax, abstol, cache, params; kwargs...)
+    taylorinteg!(f, x0, trange, abstol, cache, params; kwargs...)
+    taylorinteg!(f!, q0, trange, abstol, cache, params; kwargs...)
+
+Integrate using a preallocated `cache`, returning a [`TaylorSolution`](@ref).
+This is the in-place, cache-mutating counterpart of [`taylorinteg`](@ref); callers
+that pass the same cache repeatedly can avoid rebuilding the working Taylor polynomials.
+
+The keyword `copy_solution` controls whether the returned solution owns its
+storage:
+- `copy_solution=Val(true)`: copy the returned arrays and dense polynomials out
+  of the cache. This is the default for `taylorinteg!` and is safe when the cache
+  will be reused while earlier solutions are still needed.
+- `copy_solution=Val(false)`: return views or borrowed arrays backed by the
+  cache. This avoids the final solution copy, but the returned solution may be
+  overwritten by later reuse of the same cache.
+
+Use [`taylorinteg`](@ref) for one-shot runs; it creates a private cache
+and uses `copy_solution=Val(false)` internally to minimize allocations.
+"""
 function taylorinteg!(
     dense::Val{D},
     f,

--- a/src/integrator/taylorinteg.jl
+++ b/src/integrator/taylorinteg.jl
@@ -223,28 +223,6 @@ function taylorinteg(
                         reltol, minstepsize, maxstepsize, copy_solution=Val(false))
 end
 
-"""
-    taylorinteg!(dense::Val, f, x0, t0, tmax, abstol, cache, params; kwargs...)
-    taylorinteg!(dense::Val, f!, q0, t0, tmax, abstol, cache, params; kwargs...)
-    taylorinteg!(f, x0, trange, abstol, cache, params; kwargs...)
-    taylorinteg!(f!, q0, trange, abstol, cache, params; kwargs...)
-
-Integrate using a preallocated `cache`, returning a [`TaylorSolution`](@ref).
-This is the in-place, cache-mutating counterpart of [`taylorinteg`](@ref); callers
-that pass the same cache repeatedly can avoid rebuilding the working Taylor polynomials.
-
-The keyword `copy_solution` controls whether the returned solution owns its
-storage:
-- `copy_solution=Val(true)`: copy the returned arrays and dense polynomials out
-  of the cache. This is the default for `taylorinteg!` and is safe when the cache
-  will be reused while earlier solutions are still needed.
-- `copy_solution=Val(false)`: return views or borrowed arrays backed by the
-  cache. This avoids the final solution copy, but the returned solution may be
-  overwritten by later reuse of the same cache.
-
-Use [`taylorinteg`](@ref) for one-shot runs; it creates a private cache
-and uses `copy_solution=Val(false)` internally to minimize allocations.
-"""
 function taylorinteg!(
     dense::Val{D},
     f,
@@ -636,6 +614,32 @@ function taylorinteg!(
 
     return build_solution(copy_solution, trange, xv)
 end
+
+@doc doc"""
+    taylorinteg!(dense::Val, f, x0, t0, tmax, abstol, cache, params; kwargs...)
+    taylorinteg!(dense::Val, f!, q0, t0, tmax, abstol, cache, params; kwargs...)
+    taylorinteg!(f, x0, trange, abstol, cache, params; kwargs...)
+    taylorinteg!(f!, q0, trange, abstol, cache, params; kwargs...)
+    taylorinteg!(dense::Val, f!, g, q0, t0, tmax, abstol, cache, params; kwargs...)
+    taylorinteg!(f!, g, q0, trange, abstol, cache, params; kwargs...)
+
+Integrate using a preallocated `cache`, returning a [`TaylorSolution`](@ref).
+This is the in-place, cache-mutating counterpart of [`taylorinteg`](@ref); callers
+that pass the same cache repeatedly can avoid rebuilding the working Taylor polynomials.
+The last two signatures are the root-finding variants.
+
+The keyword `copy_solution` controls whether the returned solution owns its
+storage:
+- `copy_solution=Val(true)`: copy the returned arrays and dense polynomials out
+  of the cache. This is the default for `taylorinteg!` and is safe when the cache
+  will be reused while earlier solutions are still needed.
+- `copy_solution=Val(false)`: return views or borrowed arrays backed by the
+  cache. This avoids the final solution copy, but the returned solution may be
+  overwritten by later reuse of the same cache.
+
+Use [`taylorinteg`](@ref) for one-shot runs; it creates a private cache
+and uses `copy_solution=Val(false)` internally to minimize allocations.
+""" taylorinteg!
 
 
 # Generic functions

--- a/src/integrator/taylorinteg.jl
+++ b/src/integrator/taylorinteg.jl
@@ -7,6 +7,58 @@
     return y
 end
 
+@inline function _stored_taylor(x::TaylorN{U}) where {U<:Number}
+    y = zero(x)
+    TS.identity!(y, x)
+    return y
+end
+
+@inline _stored_value(x::Taylor1) = _stored_taylor(x)
+@inline _stored_value(x::TaylorN) = _stored_taylor(x)
+@inline _stored_value(x::T) where {T<:Number} =
+    Base.isbitstype(T) ? x : deepcopy(x)
+
+@inline function _copy_value!(dest::Taylor1{U}, src::Taylor1{U}) where {U<:Number}
+    length(dest) == length(src) || return _stored_value(src)
+    TS.identity!(dest, src)
+    return dest
+end
+
+@inline function _copy_value!(dest::TaylorN{U}, src::TaylorN{U}) where {U<:Number}
+    length(dest) == length(src) || return _stored_value(src)
+    TS.identity!(dest, src)
+    return dest
+end
+
+@inline _copy_value!(dest::T, src::T) where {T<:Number} = _stored_value(src)
+
+function _stored_state(q0::AbstractVector{U}) where {U<:Number}
+    x0 = similar(q0)
+    @inbounds for i in eachindex(q0)
+        x0[i] = _stored_value(q0[i])
+    end
+    return x0
+end
+
+function _copy_state!(dest::AbstractVector{U}, src::AbstractVector{U}) where {U<:Number}
+    @inbounds for i in eachindex(src)
+        dest[i] = _copy_value!(dest[i], src[i])
+    end
+    return dest
+end
+
+function _store_state_column!(xv::AbstractMatrix{U}, nsteps::Int,
+        x0::AbstractVector{U}) where {U<:Number}
+    @inbounds for i in eachindex(x0)
+        if Base.isbitstype(U) || !isassigned(xv, i, nsteps)
+            xv[i, nsteps] = _stored_value(x0[i])
+        else
+            xv[i, nsteps] = _copy_value!(xv[i, nsteps], x0[i])
+        end
+    end
+    return nothing
+end
+
 @inline function _store_taylor!(psol::Array{Taylor1{U},1}, nsteps::Int,
         x::Taylor1{U}) where {U<:Number}
     if isassigned(psol, nsteps)
@@ -215,10 +267,10 @@ function taylorinteg!(
     (; tv, xv, psol, xaux, t, x, dx, rv, parse_eqs) = cache
 
     # Initial conditions
-    x0 = deepcopy(q0)
+    x0 = _stored_state(q0)
     update_cache!(cache, t0, x0)
     @inbounds tv[1] = t0
-    @inbounds xv[:, 1] .= q0
+    _store_state_column!(xv, 1, q0)
     sign_tstep = copysign(1, tmax - t0)
 
     # Integration
@@ -238,7 +290,7 @@ function taylorinteg!(
         update_cache!(cache, t0, x0)
         nsteps += 1
         @inbounds tv[nsteps] = t0
-        @inbounds xv[:, nsteps] .= deepcopy.(x0)
+        _store_state_column!(xv, nsteps, x0)
         if nsteps > maxsteps
             @warn("""
             Maximum number of integration steps reached; exiting.
@@ -466,9 +518,9 @@ function taylorinteg!(
     # Initial conditions
     @inbounds t0, t1, tmax = trange[1], trange[2], trange[end]
     sign_tstep = copysign(1, tmax - t0)
-    @inbounds x0 .= deepcopy(q0)
+    _copy_state!(x0, q0)
     update_cache!(cache, t0, x0)
-    @inbounds xv[:, 1] .= q0
+    _store_state_column!(xv, 1, q0)
 
     # Integration
     iter = 2
@@ -487,12 +539,12 @@ function taylorinteg!(
         # Evaluate solution at times within convergence radius
         while sign_tstep * t1 < sign_tstep * tnext
             evaluate!(x, t1 - t0, x1)
-            @inbounds xv[:, iter] .= deepcopy.(x1)
+            _store_state_column!(xv, iter, x1)
             iter += 1
             @inbounds t1 = trange[iter]
         end
         if δt == tmax - t0
-            @inbounds xv[:, iter] .= deepcopy.(x0)
+            _store_state_column!(xv, iter, x0)
             break
         end
         t0 = tnext

--- a/src/integrator/taylorinteg.jl
+++ b/src/integrator/taylorinteg.jl
@@ -1,43 +1,30 @@
 # This file is part of the TaylorIntegration.jl package; MIT licensed
 
 """
-    _stored_taylor(x::Taylor1{U}) where {U<:Number}
-    _stored_taylor(x::TaylorN{U}) where {U<:Number}
-
-Return an independent Taylor polynomial with the same coefficients as `x`.
-
-The returned object has fresh coefficient storage and is safe to keep in an
-integration cache, dense-output cache, or returned [`TaylorSolution`](@ref) even
-if the working Taylor polynomial `x` is mutated by later integration steps.
-This is the Taylor-specific replacement for `deepcopy` used by the storage
-helpers below.
-"""
-@inline function _stored_taylor(x::Taylor1{U}) where {U<:Number}
-    y = zero(x)
-    TS.identity!(y, x)
-    return y
-end
-
-@inline function _stored_taylor(x::TaylorN{U}) where {U<:Number}
-    y = zero(x)
-    TS.identity!(y, x)
-    return y
-end
-
-"""
     _stored_value(x::Taylor1)
     _stored_value(x::TaylorN)
     _stored_value(x::T) where {T<:Number}
 
 Return a value suitable for storage in solution arrays and integration caches.
 
-Taylor polynomials are copied with [`_stored_taylor`](@ref), `isbits` numbers
-are stored directly, and other `Number` subtypes fall back to `deepcopy`. This
-gives mutable number-like values snapshot semantics while avoiding unnecessary
-copies for immutable scalar values.
+Taylor polynomials are copied into fresh coefficient storage with
+`TaylorSeries.identity!`, `isbits` numbers are stored directly, and other
+`Number` subtypes fall back to `deepcopy`. This gives mutable number-like
+values snapshot semantics while avoiding unnecessary copies for immutable scalar
+values.
 """
-@inline _stored_value(x::Taylor1) = _stored_taylor(x)
-@inline _stored_value(x::TaylorN) = _stored_taylor(x)
+@inline function _stored_value(x::Taylor1{U}) where {U<:Number}
+    y = zero(x)
+    TS.identity!(y, x)
+    return y
+end
+
+@inline function _stored_value(x::TaylorN{U}) where {U<:Number}
+    y = zero(x)
+    TS.identity!(y, x)
+    return y
+end
+
 @inline _stored_value(x::T) where {T<:Number} =
     Base.isbitstype(T) ? x : deepcopy(x)
 
@@ -158,7 +145,7 @@ column `nsteps` stores the dense polynomial for the current step.
     if isassigned(psol, nsteps)
         @inbounds TS.identity!(psol[nsteps], x)
     else
-        @inbounds psol[nsteps] = _stored_taylor(x)
+        @inbounds psol[nsteps] = _stored_value(x)
     end
     return nothing
 end
@@ -168,7 +155,7 @@ end
     if isassigned(psol, j, nsteps)
         @inbounds TS.identity!(psol[j, nsteps], x)
     else
-        @inbounds psol[j, nsteps] = _stored_taylor(x)
+        @inbounds psol[j, nsteps] = _stored_value(x)
     end
     return nothing
 end

--- a/src/integrator/taylorinteg.jl
+++ b/src/integrator/taylorinteg.jl
@@ -61,13 +61,21 @@ end
 
 @inline function _store_taylor!(psol::Array{Taylor1{U},1}, nsteps::Int,
         x::Taylor1{U}) where {U<:Number}
-    @inbounds psol[nsteps] = _stored_taylor(x)
+    if isassigned(psol, nsteps)
+        @inbounds TS.identity!(psol[nsteps], x)
+    else
+        @inbounds psol[nsteps] = _stored_taylor(x)
+    end
     return nothing
 end
 
 @inline function _store_taylor!(psol::Array{Taylor1{U},2}, j::Int, nsteps::Int,
         x::Taylor1{U}) where {U<:Number}
-    @inbounds psol[j, nsteps] = _stored_taylor(x)
+    if isassigned(psol, j, nsteps)
+        @inbounds TS.identity!(psol[j, nsteps], x)
+    else
+        @inbounds psol[j, nsteps] = _stored_taylor(x)
+    end
     return nothing
 end
 
@@ -162,7 +170,7 @@ function taylorinteg(
     cache = init_cache(Val(dense), t0, x0, maxsteps, order, f, params; parse_eqs)
 
     return taylorinteg!(Val(dense), f, x0, t0, tmax, abstol, cache, params; maxsteps,
-                        reltol, minstepsize, maxstepsize)
+                        reltol, minstepsize, maxstepsize, copy_solution=Val(false))
 end
 
 function taylorinteg!(
@@ -177,7 +185,8 @@ function taylorinteg!(
     maxsteps::Int = 500,
     reltol::T = zero(T),
     minstepsize::T = zero(T),
-    maxstepsize::T = T(Inf)
+    maxstepsize::T = T(Inf),
+    copy_solution::Val = Val(true)
 ) where {T<:Real,U<:Number,D}
 
     (; tv, xv, psol, t, x, rv, parse_eqs) = cache
@@ -214,7 +223,7 @@ function taylorinteg!(
         end
     end
 
-    return build_solution(tv, xv, psol, nsteps)
+    return build_solution(copy_solution, tv, xv, psol, nsteps)
 end
 
 
@@ -238,7 +247,7 @@ function taylorinteg(
     cache = init_cache(Val(dense), t0, q0, maxsteps, order, f!, params; parse_eqs)
 
     return taylorinteg!(Val(dense), f!, q0, t0, tmax, abstol, cache, params; maxsteps,
-                        reltol, minstepsize, maxstepsize)
+                        reltol, minstepsize, maxstepsize, copy_solution=Val(false))
 end
 
 function taylorinteg!(
@@ -253,7 +262,8 @@ function taylorinteg!(
     maxsteps::Int = 500,
     reltol::T = zero(T),
     minstepsize::T = zero(T),
-    maxstepsize::T = T(Inf)
+    maxstepsize::T = T(Inf),
+    copy_solution::Val = Val(true)
 ) where {T<:Real,U<:Number,D}
 
     (; tv, xv, psol, xaux, t, x, dx, rv, parse_eqs) = cache
@@ -291,7 +301,7 @@ function taylorinteg!(
         end
     end
 
-    return build_solution(tv, xv, psol, nsteps)
+    return build_solution(copy_solution, tv, xv, psol, nsteps)
 end
 
 @doc doc"""
@@ -406,7 +416,7 @@ function taylorinteg(
     cache = init_cache(Val(false), trange, x0, maxsteps, order, f, params; parse_eqs)
 
     return taylorinteg!(f, x0, trange, abstol, cache, params; maxsteps, reltol,
-                        minstepsize, maxstepsize)
+                        minstepsize, maxstepsize, copy_solution=Val(false))
 end
 
 function taylorinteg!(
@@ -419,7 +429,8 @@ function taylorinteg!(
     maxsteps::Int = 500,
     reltol::T = zero(T),
     minstepsize::T = zero(T),
-    maxstepsize::T = T(Inf)
+    maxstepsize::T = T(Inf),
+    copy_solution::Val = Val(true)
 ) where {T<:Real,U<:Number}
 
     (; xv, t, x, rv, parse_eqs) = cache
@@ -465,7 +476,7 @@ function taylorinteg!(
             break
         end
     end
-    return build_solution(trange, xv)
+    return build_solution(copy_solution, trange, xv)
 end
 
 function taylorinteg(
@@ -489,7 +500,7 @@ function taylorinteg(
     cache = init_cache(Val(false), trange, q0, maxsteps, order, f!, params; parse_eqs)
 
     return taylorinteg!(f!, q0, trange, abstol, cache, params; maxsteps, reltol,
-                        minstepsize, maxstepsize)
+                        minstepsize, maxstepsize, copy_solution=Val(false))
 end
 
 function taylorinteg!(
@@ -502,7 +513,8 @@ function taylorinteg!(
     maxsteps::Int = 500,
     reltol::T = zero(T),
     minstepsize::T = zero(T),
-    maxstepsize::T = T(Inf)
+    maxstepsize::T = T(Inf),
+    copy_solution::Val = Val(true)
 ) where {T<:Real,U<:Number}
 
     (; xv, xaux, x0, x1, t, x, dx, rv, parse_eqs) = cache
@@ -550,7 +562,7 @@ function taylorinteg!(
         end
     end
 
-    return build_solution(trange, xv)
+    return build_solution(copy_solution, trange, xv)
 end
 
 

--- a/src/integrator/taylorsolution.jl
+++ b/src/integrator/taylorsolution.jl
@@ -169,8 +169,8 @@ end
     ownedsol(a)
 
 Return an owned solution array copied from `a`. The two-argument method first
-selects the first `n` solution entries with [`arraysol`](@ref), then copies
-them into independent storage.
+selects the first `n` solution entries with `arraysol`, then copies them into
+independent storage.
 """
 ownedsol(::Nothing, ::Int) = nothing
 ownedsol(a::AbstractArray, n::Int) = _owned_array(arraysol(a, n))

--- a/src/integrator/taylorsolution.jl
+++ b/src/integrator/taylorsolution.jl
@@ -138,11 +138,17 @@ function TaylorSolution(t::AbstractVector, p::AbstractArray{<:Taylor1})
 end
 
 """
-    arraysol(a, n)
+    arraysol(::Nothing, n::Int)
+    arraysol(v::AbstractVector, n::Int)
+    arraysol(m::AbstractMatrix, n::Int)
 
 Return the first `n` stored solution entries in the orientation expected by
 [`TaylorSolution`](@ref). Vectors are returned as views, and matrices stored as
 `variables x steps` are returned as transposed `steps x variables` views.
+
+This is the low-allocation path used when a returned solution is allowed to
+borrow storage from the integration cache. The returned arrays may alias the
+cache and can be overwritten if the same cache is reused.
 """
 
 arraysol(::Nothing, ::Int) = nothing
@@ -150,11 +156,14 @@ arraysol(v::AbstractVector, n::Int) = view(v, 1:n)
 arraysol(m::AbstractMatrix, n::Int) = view(transpose(view(m, :, 1:n)), 1:n, :)
 
 """
-    _owned_array(a)
+    _owned_array(a::AbstractArray{U}) where {U<:Number}
 
 Return an owned `Array` copy of `a`, copying each element with
 `_stored_value`. This preserves snapshot semantics for mutable number-like
 entries such as `Taylor1` and `TaylorN`.
+
+This differs from a shallow array copy because mutable Taylor polynomial entries
+are copied into independent coefficient storage.
 """
 function _owned_array(a::AbstractArray{U}) where {U<:Number}
     out = Array{U}(undef, size(a))
@@ -165,12 +174,16 @@ function _owned_array(a::AbstractArray{U}) where {U<:Number}
 end
 
 """
+    ownedsol(::Nothing, n::Int)
     ownedsol(a, n)
     ownedsol(a)
 
 Return an owned solution array copied from `a`. The two-argument method first
 selects the first `n` solution entries with `arraysol`, then copies them into
 independent storage.
+
+Use this when a returned [`TaylorSolution`](@ref) must remain valid after the
+integration cache is reused.
 """
 ownedsol(::Nothing, ::Int) = nothing
 ownedsol(a::AbstractArray, n::Int) = _owned_array(arraysol(a, n))
@@ -185,6 +198,10 @@ ownedsol(a::AbstractArray) = _owned_array(a)
 Select the array storage used in a returned [`TaylorSolution`](@ref).
 `Val(false)` returns the borrowed/view-backed storage used by the low-allocation
 path, while `Val(true)` returns owned arrays with independent entries.
+
+The three-argument methods first select the active portion of a preallocated
+cache array; the two-argument methods are used for already-sized time-range
+solutions.
 """
 solution_array(::Val{false}, a, n::Int) = arraysol(a, n)
 solution_array(::Val{true}, a, n::Int) = ownedsol(a, n)
@@ -205,6 +222,12 @@ Helper function to build a [`TaylorSolution`](@ref) from a call to
 When `copy_solution` is `Val(false)`, the returned solution borrows views of the
 given arrays. When `copy_solution` is `Val(true)`, the returned solution owns
 independent copies of the arrays and Taylor polynomials.
+
+For vector-valued integrations, cache arrays are stored internally as
+`variables x steps`; these methods expose them through [`TaylorSolution`](@ref)
+as `steps x variables`. Dense-output polynomial arrays `p` are trimmed to
+`nsteps - 1`, since each dense polynomial represents one completed integration
+step.
 """
 build_solution(t::AbstractVector{T}, x::Vector{U}, ::Nothing, nsteps::Int) where {T,U} =
     build_solution(Val(false), t, x, nothing, nsteps)

--- a/src/integrator/taylorsolution.jl
+++ b/src/integrator/taylorsolution.jl
@@ -143,6 +143,23 @@ arraysol(::Nothing, ::Int) = nothing
 arraysol(v::AbstractVector, n::Int) = view(v, 1:n)
 arraysol(m::AbstractMatrix, n::Int) = view(transpose(view(m, :, 1:n)), 1:n, :)
 
+function _owned_array(a::AbstractArray{U}) where {U<:Number}
+    out = Array{U}(undef, size(a))
+    @inbounds for i in eachindex(a)
+        out[i] = _stored_value(a[i])
+    end
+    return out
+end
+
+ownedsol(::Nothing, ::Int) = nothing
+ownedsol(a::AbstractArray, n::Int) = _owned_array(arraysol(a, n))
+ownedsol(a::AbstractArray) = _owned_array(a)
+
+solution_array(::Val{false}, a, n::Int) = arraysol(a, n)
+solution_array(::Val{true}, a, n::Int) = ownedsol(a, n)
+solution_array(::Val{false}, a) = a
+solution_array(::Val{true}, a) = ownedsol(a)
+
 # build_solution
 
 """
@@ -154,27 +171,77 @@ Helper function to build a [`TaylorSolution`](@ref) from a call to
 
 """
 build_solution(t::AbstractVector{T}, x::Vector{U}, ::Nothing, nsteps::Int) where {T,U} =
-    TaylorSolution(arraysol(t, nsteps), arraysol(x, nsteps), nothing)
+    build_solution(Val(false), t, x, nothing, nsteps)
+
+build_solution(::Val{C}, t::AbstractVector{T}, x::Vector{U}, ::Nothing,
+        nsteps::Int) where {C,T,U} =
+    TaylorSolution(solution_array(Val(C), t, nsteps), solution_array(Val(C), x, nsteps),
+                   nothing)
+
 build_solution(
     t::AbstractVector{T},
     x::Vector{U},
     p::Vector{Taylor1{U}},
     nsteps::Int,
 ) where {T,U} =
-    TaylorSolution(arraysol(t, nsteps), arraysol(x, nsteps), arraysol(p, nsteps - 1))
+    build_solution(Val(false), t, x, p, nsteps)
+
+function build_solution(
+    copy_solution::Val{C},
+    t::AbstractVector{T},
+    x::Vector{U},
+    p::Vector{Taylor1{U}},
+    nsteps::Int,
+) where {C,T,U}
+    return TaylorSolution(
+        solution_array(copy_solution, t, nsteps),
+        solution_array(copy_solution, x, nsteps),
+        solution_array(copy_solution, p, nsteps - 1),
+    )
+end
+
 build_solution(t::AbstractVector{T}, x::Matrix{U}, ::Nothing, nsteps::Int) where {T,U} =
-    TaylorSolution(arraysol(t, nsteps), arraysol(x, nsteps), nothing)
+    build_solution(Val(false), t, x, nothing, nsteps)
+
+build_solution(::Val{C}, t::AbstractVector{T}, x::Matrix{U}, ::Nothing,
+        nsteps::Int) where {C,T,U} =
+    TaylorSolution(solution_array(Val(C), t, nsteps), solution_array(Val(C), x, nsteps),
+                   nothing)
+
 build_solution(
     t::AbstractVector{T},
     x::Matrix{U},
     p::Matrix{Taylor1{U}},
     nsteps::Int,
 ) where {T,U} =
-    TaylorSolution(arraysol(t, nsteps), arraysol(x, nsteps), arraysol(p, nsteps - 1))
+    build_solution(Val(false), t, x, p, nsteps)
 
-build_solution(t::AbstractVector{T}, x::Vector{U}) where {T,U} = TaylorSolution(t, x, nothing)
+function build_solution(
+    copy_solution::Val{C},
+    t::AbstractVector{T},
+    x::Matrix{U},
+    p::Matrix{Taylor1{U}},
+    nsteps::Int,
+) where {C,T,U}
+    return TaylorSolution(
+        solution_array(copy_solution, t, nsteps),
+        solution_array(copy_solution, x, nsteps),
+        solution_array(copy_solution, p, nsteps - 1),
+    )
+end
+
+build_solution(t::AbstractVector{T}, x::Vector{U}) where {T,U} =
+    build_solution(Val(false), t, x)
+
+build_solution(copy_solution::Val, t::AbstractVector{T}, x::Vector{U}) where {T,U} =
+    TaylorSolution(solution_array(copy_solution, t), solution_array(copy_solution, x), nothing)
+
 build_solution(t::AbstractVector{T}, x::Matrix{U}) where {T,U} =
-    TaylorSolution(t, transpose(x), nothing)
+    build_solution(Val(false), t, x)
+
+build_solution(copy_solution::Val, t::AbstractVector{T}, x::Matrix{U}) where {T,U} =
+    TaylorSolution(solution_array(copy_solution, t), solution_array(copy_solution, transpose(x)),
+                   nothing)
 
 ### Custom print
 

--- a/src/integrator/taylorsolution.jl
+++ b/src/integrator/taylorsolution.jl
@@ -137,12 +137,25 @@ function TaylorSolution(t::AbstractVector, p::AbstractArray{<:Taylor1})
     end
 end
 
-# arraysol: auxiliary function for solution construction
+"""
+    arraysol(a, n)
+
+Return the first `n` stored solution entries in the orientation expected by
+[`TaylorSolution`](@ref). Vectors are returned as views, and matrices stored as
+`variables x steps` are returned as transposed `steps x variables` views.
+"""
 
 arraysol(::Nothing, ::Int) = nothing
 arraysol(v::AbstractVector, n::Int) = view(v, 1:n)
 arraysol(m::AbstractMatrix, n::Int) = view(transpose(view(m, :, 1:n)), 1:n, :)
 
+"""
+    _owned_array(a)
+
+Return an owned `Array` copy of `a`, copying each element with
+`_stored_value`. This preserves snapshot semantics for mutable number-like
+entries such as `Taylor1` and `TaylorN`.
+"""
 function _owned_array(a::AbstractArray{U}) where {U<:Number}
     out = Array{U}(undef, size(a))
     @inbounds for i in eachindex(a)
@@ -151,10 +164,28 @@ function _owned_array(a::AbstractArray{U}) where {U<:Number}
     return out
 end
 
+"""
+    ownedsol(a, n)
+    ownedsol(a)
+
+Return an owned solution array copied from `a`. The two-argument method first
+selects the first `n` solution entries with [`arraysol`](@ref), then copies
+them into independent storage.
+"""
 ownedsol(::Nothing, ::Int) = nothing
 ownedsol(a::AbstractArray, n::Int) = _owned_array(arraysol(a, n))
 ownedsol(a::AbstractArray) = _owned_array(a)
 
+"""
+    solution_array(::Val{false}, a, n)
+    solution_array(::Val{true}, a, n)
+    solution_array(::Val{false}, a)
+    solution_array(::Val{true}, a)
+
+Select the array storage used in a returned [`TaylorSolution`](@ref).
+`Val(false)` returns the borrowed/view-backed storage used by the low-allocation
+path, while `Val(true)` returns owned arrays with independent entries.
+"""
 solution_array(::Val{false}, a, n::Int) = arraysol(a, n)
 solution_array(::Val{true}, a, n::Int) = ownedsol(a, n)
 solution_array(::Val{false}, a) = a
@@ -165,10 +196,15 @@ solution_array(::Val{true}, a) = ownedsol(a)
 """
     build_solution(t, x, p, nsteps)
     build_solution(t, x)
+    build_solution(copy_solution::Val, t, x, p, nsteps)
+    build_solution(copy_solution::Val, t, x)
 
 Helper function to build a [`TaylorSolution`](@ref) from a call to
 [`taylorinteg`](@ref).
 
+When `copy_solution` is `Val(false)`, the returned solution borrows views of the
+given arrays. When `copy_solution` is `Val(true)`, the returned solution owns
+independent copies of the arrays and Taylor polynomials.
 """
 build_solution(t::AbstractVector{T}, x::Vector{U}, ::Nothing, nsteps::Int) where {T,U} =
     build_solution(Val(false), t, x, nothing, nsteps)

--- a/src/rootfinding.jl
+++ b/src/rootfinding.jl
@@ -1,5 +1,8 @@
 ### `build_solution` method for root-finding
 
+@inline _stored_event_tuple(g_tupl::Tuple{Bool,<:Taylor1}) =
+    (g_tupl[1], _stored_value(g_tupl[2]))
+
 @doc doc"""
     build_solution(t, x, p, tevents, xevents, gresids, nsteps, nevents)
     build_solution(t, x, tevents, xevents, gresids, nsteps, nevents)
@@ -163,8 +166,8 @@ function findroot!(
         evaluate!(x_dx, dt_nr, view(x_dx_val, :))
 
         tvS[nevents] = t0 + dt_nr
-        xvS[:, nevents] .= deepcopy.(view(x_dx_val, 1:dof))
-        gvS[nevents] = deepcopy(g_dg_val[1])
+        _store_state_column!(xvS, nevents, view(x_dx_val, 1:dof))
+        gvS[nevents] = _stored_value(g_dg_val[1])
 
         nevents += 1
     end
@@ -303,15 +306,15 @@ function taylorinteg!(
     (; tv, xv, psol, xaux, t, x, dx, rv, parse_eqs) = cache
 
     # Initial conditions
-    x0 = deepcopy(q0)
+    x0 = _stored_state(q0)
     update_cache!(cache, t0, x0)
     @inbounds tv[1] = t0
-    @inbounds xv[:, 1] .= deepcopy(q0)
+    _store_state_column!(xv, 1, q0)
     sign_tstep = copysign(1, tmax - t0)
 
     # Some auxiliary arrays for root-finding/event detection/Poincaré surface of section evaluation
     g_tupl = g(dx, x, params, t)
-    g_tupl_old = deepcopy(g_tupl)
+    g_tupl_old = _stored_event_tuple(g_tupl)
     δt = zero(x[1])
     δt_old = zero(x[1])
 
@@ -356,12 +359,12 @@ function taylorinteg!(
             newtoniter,
             nevents,
         )
-        g_tupl_old = deepcopy(g_tupl)
+        g_tupl_old = _stored_event_tuple(g_tupl)
         t0 += δt
         update_cache!(cache, t0, x0)
         nsteps += 1
         @inbounds tv[nsteps] = t0
-        @inbounds xv[:, nsteps] .= deepcopy(x0)
+        _store_state_column!(xv, nsteps, x0)
         if nsteps > maxsteps
             @warn("""
             Maximum number of integration steps reached; exiting.
@@ -439,13 +442,13 @@ function taylorinteg!(
     # Initial conditions
     @inbounds t0, t1, tmax = trange[1], trange[2], trange[end]
     sign_tstep = copysign(1, tmax - t0)
-    @inbounds x0 .= deepcopy(q0)
+    _copy_state!(x0, q0)
     update_cache!(cache, t0, x0)
-    @inbounds xv[:, 1] .= deepcopy(q0)
+    _store_state_column!(xv, 1, q0)
 
     # Some auxiliary arrays for root-finding/event detection/Poincaré surface of section evaluation
     g_tupl = g(dx, x, params, t)
-    g_tupl_old = deepcopy(g_tupl)
+    g_tupl_old = _stored_event_tuple(g_tupl)
     δt = zero(U)
     δt_old = zero(U)
 
@@ -473,12 +476,12 @@ function taylorinteg!(
         # Evaluate solution at times within convergence radius
         while sign_tstep * t1 < sign_tstep * tnext
             evaluate!(x, t1 - t0, x1)
-            @inbounds xv[:, iter] .= deepcopy(x1)
+            _store_state_column!(xv, iter, x1)
             iter += 1
             @inbounds t1 = trange[iter]
         end
         if δt == tmax - t0
-            @inbounds xv[:, iter] .= deepcopy(x0)
+            _store_state_column!(xv, iter, x0)
             break
         end
         g_tupl = g(dx, x, params, t)
@@ -502,7 +505,7 @@ function taylorinteg!(
             newtoniter,
             nevents,
         )
-        g_tupl_old = deepcopy(g_tupl)
+        g_tupl_old = _stored_event_tuple(g_tupl)
         t0 = tnext
         update_cache!(cache, t0, x0)
         nsteps += 1

--- a/src/rootfinding.jl
+++ b/src/rootfinding.jl
@@ -1,15 +1,27 @@
 ### `build_solution` method for root-finding
 
+"""
+    _stored_event_tuple(g_tupl)
+
+Return an event tuple whose polynomial component is independent of `g_tupl`.
+This keeps root-finding state snapshots from aliasing the mutable Taylor
+polynomials used by the integration cache.
+"""
 @inline _stored_event_tuple(g_tupl::Tuple{Bool,<:Taylor1}) =
     (g_tupl[1], _stored_value(g_tupl[2]))
 
 @doc doc"""
     build_solution(t, x, p, tevents, xevents, gresids, nsteps, nevents)
     build_solution(t, x, tevents, xevents, gresids, nsteps, nevents)
+    build_solution(copy_solution::Val, t, x, p, tevents, xevents, gresids, nsteps, nevents)
+    build_solution(copy_solution::Val, t, x, tevents, xevents, gresids, nevents)
 
 Helper function to build a [`TaylorSolution`](@ref) from a call to a
 root-finding method of [`taylorinteg`](@ref).
 
+When `copy_solution` is `Val(false)`, the returned solution borrows views of the
+given arrays. When `copy_solution` is `Val(true)`, `t`, `x`, `p`, `tevents`,
+`xevents` and `gresids` are copied into independent owned storage.
 """
 build_solution(
     t::AbstractVector{T},
@@ -323,6 +335,22 @@ function taylorinteg(
     )
 end
 
+"""
+    taylorinteg!(dense::Val, f!, g, q0, t0, tmax, abstol, cache, params; kwargs...)
+    taylorinteg!(f!, g, q0, trange, abstol, cache, params; kwargs...)
+
+Root-finding variant of [`taylorinteg!`](@ref) using a preallocated `cache`.
+Besides the solution arrays and dense polynomials, the returned
+[`TaylorSolution`](@ref) may also contain `tevents`, `xevents` and `gresids`.
+
+The keyword `copy_solution` controls ownership of all returned storage:
+- `copy_solution=Val(true)`: copy the returned arrays and dense polynomials out
+  of the cache. This is the default for `taylorinteg!` and is safe when the cache
+  will be reused while earlier root-finding solutions are still needed.
+- `copy_solution=Val(false)`: return views or borrowed arrays backed by the
+  cache. This avoids the final solution copy, but the returned solution may be
+  overwritten by later reuse of the same cache.
+"""
 function taylorinteg!(
     dense::Val{D},
     f!,

--- a/src/rootfinding.jl
+++ b/src/rootfinding.jl
@@ -30,6 +30,26 @@ build_solution(
     nothing,
 )
 
+build_solution(
+    copy_solution::Val{C},
+    t::AbstractVector{T},
+    x::Matrix{U},
+    p::P,
+    tevents::AbstractVector{U},
+    xevents::Matrix{U},
+    gresids::AbstractVector{U},
+    nsteps::Int,
+    nevents::Int,
+) where {C,T,U,P<:Union{Nothing,Matrix{Taylor1{U}}}} = TaylorSolution(
+    solution_array(copy_solution, t, nsteps),
+    solution_array(copy_solution, x, nsteps),
+    solution_array(copy_solution, p, nsteps - 1),
+    solution_array(copy_solution, tevents, nevents - 1),
+    solution_array(copy_solution, xevents, nevents - 1),
+    solution_array(copy_solution, gresids, nevents - 1),
+    nothing,
+)
+
 #### `build_solution` method for root-finding with time-ranges
 
 build_solution(
@@ -46,6 +66,24 @@ build_solution(
     arraysol(tevents, nevents - 1),
     arraysol(xevents, nevents - 1),
     arraysol(gresids, nevents - 1),
+    nothing,
+)
+
+build_solution(
+    copy_solution::Val{C},
+    t::AbstractVector{T},
+    x::Matrix{U},
+    tevents::AbstractVector{U},
+    xevents::Matrix{U},
+    gresids::AbstractVector{U},
+    nevents::Int,
+) where {C,T,U} = TaylorSolution(
+    solution_array(copy_solution, t),
+    solution_array(copy_solution, transpose(x)),
+    nothing,
+    solution_array(copy_solution, tevents, nevents - 1),
+    solution_array(copy_solution, xevents, nevents - 1),
+    solution_array(copy_solution, gresids, nevents - 1),
     nothing,
 )
 
@@ -280,7 +318,8 @@ function taylorinteg(
         nrabstol,
         reltol,
         minstepsize,
-        maxstepsize
+        maxstepsize,
+        copy_solution=Val(false)
     )
 end
 
@@ -300,7 +339,8 @@ function taylorinteg!(
     nrabstol::T = eps(T),
     reltol::T = zero(T),
     minstepsize::T = zero(T),
-    maxstepsize::T = T(Inf)
+    maxstepsize::T = T(Inf),
+    copy_solution::Val = Val(true)
 ) where {T<:Real,U<:Number,D}
 
     (; tv, xv, psol, xaux, t, x, dx, rv, parse_eqs) = cache
@@ -373,7 +413,7 @@ function taylorinteg!(
         end
     end
 
-    return build_solution(tv, xv, psol, tvS, xvS, gvS, nsteps, nevents)
+    return build_solution(copy_solution, tv, xv, psol, tvS, xvS, gvS, nsteps, nevents)
 end
 
 function taylorinteg(
@@ -416,7 +456,8 @@ function taylorinteg(
         nrabstol,
         reltol,
         minstepsize,
-        maxstepsize
+        maxstepsize,
+        copy_solution=Val(false)
     )
 end
 
@@ -434,7 +475,8 @@ function taylorinteg!(
     nrabstol::T = eps(T),
     reltol::T = zero(T),
     minstepsize::T = zero(T),
-    maxstepsize::T = T(Inf)
+    maxstepsize::T = T(Inf),
+    copy_solution::Val = Val(true)
 ) where {T<:Real,U<:Number}
 
     (; tv, xv, xaux, x0, x1, t, x, dx, rv, parse_eqs) = cache
@@ -517,5 +559,5 @@ function taylorinteg!(
         end
     end
 
-    return build_solution(trange, xv, tvS, xvS, gvS, nevents)
+    return build_solution(copy_solution, trange, xv, tvS, xvS, gvS, nevents)
 end

--- a/src/rootfinding.jl
+++ b/src/rootfinding.jl
@@ -1,11 +1,14 @@
 ### `build_solution` method for root-finding
 
 """
-    _stored_event_tuple(g_tupl)
+    _stored_event_tuple(g_tupl::Tuple{Bool,<:Taylor1})
 
 Return an event tuple whose polynomial component is independent of `g_tupl`.
 This keeps root-finding state snapshots from aliasing the mutable Taylor
 polynomials used by the integration cache.
+
+The Boolean crossing-direction flag is immutable and is reused directly. The
+Taylor polynomial residual is copied through [`_stored_value`](@ref).
 """
 @inline _stored_event_tuple(g_tupl::Tuple{Bool,<:Taylor1}) =
     (g_tupl[1], _stored_value(g_tupl[2]))
@@ -22,6 +25,12 @@ root-finding method of [`taylorinteg`](@ref).
 When `copy_solution` is `Val(false)`, the returned solution borrows views of the
 given arrays. When `copy_solution` is `Val(true)`, `t`, `x`, `p`, `tevents`,
 `xevents` and `gresids` are copied into independent owned storage.
+
+The step arrays are trimmed to `nsteps`, dense-output polynomial arrays are
+trimmed to `nsteps - 1`, and event arrays are trimmed to `nevents - 1` because
+`nevents` is maintained as the next insertion index. Vector state arrays are
+stored internally as `variables x steps` and exposed through
+[`TaylorSolution`](@ref) as `steps x variables`.
 """
 build_solution(
     t::AbstractVector{T},

--- a/src/rootfinding.jl
+++ b/src/rootfinding.jl
@@ -335,22 +335,6 @@ function taylorinteg(
     )
 end
 
-"""
-    taylorinteg!(dense::Val, f!, g, q0, t0, tmax, abstol, cache, params; kwargs...)
-    taylorinteg!(f!, g, q0, trange, abstol, cache, params; kwargs...)
-
-Root-finding variant of [`taylorinteg!`](@ref) using a preallocated `cache`.
-Besides the solution arrays and dense polynomials, the returned
-[`TaylorSolution`](@ref) may also contain `tevents`, `xevents` and `gresids`.
-
-The keyword `copy_solution` controls ownership of all returned storage:
-- `copy_solution=Val(true)`: copy the returned arrays and dense polynomials out
-  of the cache. This is the default for `taylorinteg!` and is safe when the cache
-  will be reused while earlier root-finding solutions are still needed.
-- `copy_solution=Val(false)`: return views or borrowed arrays backed by the
-  cache. This avoids the final solution copy, but the returned solution may be
-  overwritten by later reuse of the same cache.
-"""
 function taylorinteg!(
     dense::Val{D},
     f!,

--- a/test/common.jl
+++ b/test/common.jl
@@ -317,7 +317,7 @@ import Logging: Warn
             dq[4] = q[2] * newtonianCoeff
             return nothing
         end
-        p = variables!("ξ", numvars = 4, order = 2)
+        p = variables!("ξ", numvars = 4, order = 2, nowarn = true)
         q0 = [0.2, 0.0, 0.0, 3.0]
         q0TN = q0 + p
         tspan = (0.0, 10pi)

--- a/test/jettransport.jl
+++ b/test/jettransport.jl
@@ -17,7 +17,7 @@ import Logging: Warn
     g(x, p, t) = 0.3x
 
     @testset "Test TaylorN jet transport (t0, tmax): 1-dim case" begin
-        p = variables!("ξ", numvars = 1, order = 5)
+        p = variables!("ξ", numvars = 1, order = 5, nowarn = true)
         x0 = 3.0 #"nominal" initial condition
         x0TN = x0 + p[1] #jet transport initial condition
         t0 = 0.0
@@ -384,7 +384,7 @@ import Logging: Warn
     end
 
     @testset "Test TaylorN jet transport (trange): 1-dim case" begin
-        p = variables!("ξ", numvars = 1, order = 5)
+        p = variables!("ξ", numvars = 1, order = 5, nowarn = true)
         x0 = 3.0 #"nominal" initial condition
         x0TN = x0 + p[1] #jet transport initial condition
         tv = 0.0:0.05:0.33
@@ -641,7 +641,7 @@ import Logging: Warn
         end
 
         @testset "Test TaylorN jet transport (t0,tmax): harmonic oscillator" begin
-            p = variables!("ξ", numvars = 2, order = 5)
+            p = variables!("ξ", numvars = 2, order = 5, nowarn = true)
             x0 = [-1.0, 0.45]
             x0TN = x0 + p
             solTN = (@test_logs (Warn, max_iters_reached()) taylorinteg(
@@ -704,7 +704,7 @@ import Logging: Warn
 
     @testset "Test TaylorN jet transport (trange): simple pendulum" begin
         varorder = 2 #the order of the variational expansion
-        p = variables!("ξ", numvars = 2, order = varorder) #TaylorN steup
+        p = variables!("ξ", numvars = 2, order = varorder, nowarn = true) #TaylorN steup
         q0 = [1.3, 0.0] #the initial conditions
         q0TN = q0 + p #parametrization of a small neighbourhood around the initial conditions
         # T is the librational period == 4Elliptic.K(sin(q0[1]/2)^2)

--- a/test/lyapunov.jl
+++ b/test/lyapunov.jl
@@ -44,7 +44,7 @@ import Logging: Warn
 
     @testset "Test `stabilitymatrix!`" begin
         t0 = rand() #the initial time
-        xi = variables!("δ", order = 1, numvars = 3)
+        xi = variables!("δ", order = 1, numvars = 3, nowarn = true)
         t_ = Taylor1([t0, 1], _order)
         δx = Array{TaylorN{Taylor1{Float64}}}(undef, 3)
         dδx = similar(δx)
@@ -122,7 +122,7 @@ import Logging: Warn
         dx = similar(x)
 
         #Calculate trace of Lorenz system Jacobian via TaylorSeries.jacobian:
-        xi = variables!("δ", order = 1, numvars = length(q0))
+        xi = variables!("δ", order = 1, numvars = length(q0), nowarn = true)
         q0TN = [q0[1] + xi[1], q0[2] + xi[2], q0[3] + xi[3]]
         dq0TN = similar(q0TN)
         lorenz!(dq0TN, q0TN, nothing, t0)
@@ -140,7 +140,7 @@ import Logging: Warn
         @test constant_term.(jac) == jac_autodiff
 
         # Number of TaylorN variables should be equal to length of vector of initial conditions
-        xi = variables!("δ", order = 1, numvars = length(q0) - 1)
+        xi = variables!("δ", order = 1, numvars = length(q0) - 1, nowarn = true)
         @test_throws AssertionError lyap_taylorinteg(
             lorenz!,
             q0,
@@ -150,7 +150,7 @@ import Logging: Warn
             _abstol;
             maxsteps = 2,
         )
-        xi = variables!("δ", order = 1, numvars = length(q0))
+        xi = variables!("δ", order = 1, numvars = length(q0), nowarn = true)
 
         #Test lyap_taylorinteg with autodiff-computed Jacobian, maxsteps=5
         sol = (@test_logs (Warn, max_iters_reached()) lyap_taylorinteg(
@@ -326,7 +326,7 @@ import Logging: Warn
         tmax = t0 + 20.0 #final time of integration
 
         #Calculate trace of Lorenz system Jacobian via TaylorSeries.jacobian:
-        xi = variables!("δ", order = 1, numvars = length(q0))
+        xi = variables!("δ", order = 1, numvars = length(q0), nowarn = true)
         q0TN = q0 + xi
         dq0TN = similar(q0TN)
         lorenz!(dq0TN, q0TN, nothing, t0)

--- a/test/many_ode.jl
+++ b/test/many_ode.jl
@@ -37,22 +37,6 @@ import Logging: Warn
         δt = (_abstol / q0T[1].coeffs[end-1])^inv(_order - 1)
         @test TaylorIntegration.stepsize(q0T, _abstol) == δt
 
-        function norm_based_stepsize(x, epsilon)
-            ord = order(x)
-            return min(
-                (epsilon / norm(x[ord-1], Inf))^inv(ord - 1),
-                (epsilon / norm(x[ord], Inf))^inv(ord),
-            )
-        end
-
-        function norm_based_stepsize(q::AbstractVector, epsilon)
-            h = typemax(Float64)
-            for i in eachindex(q)
-                h = min(h, norm_based_stepsize(q[i], epsilon))
-            end
-            return h
-        end
-
         x0T1 = Taylor1(Taylor1([1.0, 0.2], 2), 5)
         x1T1 = Taylor1(Taylor1([-2.0, 0.1], 2), 5)
         x0T1[4] = Taylor1([2.0, -3.0], 2)
@@ -60,7 +44,16 @@ import Logging: Warn
         x1T1[4] = Taylor1([3.0, 0.1], 2)
         x1T1[5] = Taylor1([-0.5, 0.2], 2)
         qT1 = [x0T1, x1T1]
-        @test TaylorIntegration.stepsize(qT1, _abstol) ≈ norm_based_stepsize(qT1, _abstol)
+        expected_nested_stepsize = min(
+            (_abstol / 3.0)^inv(4),
+            (_abstol / 4.0)^inv(5),
+            (_abstol / 0.5)^inv(5),
+        )
+        @test TI._norminf(x0T1[4]) == 3.0
+        @test TI._norminf(x0T1[5]) == 4.0
+        @test TI._norminf(x1T1[4]) == 3.0
+        @test TI._norminf(x1T1[5]) == 0.5
+        @test TaylorIntegration.stepsize(qT1, _abstol) ≈ expected_nested_stepsize
 
         vars = variables!("xi", numvars=2, order=2, nowarn = true)
         x0TN = Taylor1(1.0 + vars[1], 5)
@@ -70,7 +63,11 @@ import Logging: Warn
         x1TN[4] = 3.0 + 0.1 * vars[1]
         x1TN[5] = -0.5 + 0.2 * vars[2]
         qTN = [x0TN, x1TN]
-        @test TaylorIntegration.stepsize(qTN, _abstol) ≈ norm_based_stepsize(qTN, _abstol)
+        @test TI._norminf(x0TN[4]) == 3.0
+        @test TI._norminf(x0TN[5]) == 4.0
+        @test TI._norminf(x1TN[4]) == 3.0
+        @test TI._norminf(x1TN[5]) == 0.5
+        @test TaylorIntegration.stepsize(qTN, _abstol) ≈ expected_nested_stepsize
 
         sol = @test_logs(
             (Warn, zero_stepsize()),

--- a/test/many_ode.jl
+++ b/test/many_ode.jl
@@ -62,7 +62,7 @@ import Logging: Warn
         qT1 = [x0T1, x1T1]
         @test TaylorIntegration.stepsize(qT1, _abstol) ≈ norm_based_stepsize(qT1, _abstol)
 
-        vars = variables!("xi", numvars=2, order=2)
+        vars = variables!("xi", numvars=2, order=2, nowarn = true)
         x0TN = Taylor1(1.0 + vars[1], 5)
         x1TN = Taylor1(-2.0 + vars[2], 5)
         x0TN[4] = 2.0 - 3.0 * vars[1]

--- a/test/many_ode.jl
+++ b/test/many_ode.jl
@@ -37,6 +37,41 @@ import Logging: Warn
         δt = (_abstol / q0T[1].coeffs[end-1])^inv(_order - 1)
         @test TaylorIntegration.stepsize(q0T, _abstol) == δt
 
+        function norm_based_stepsize(x, epsilon)
+            ord = order(x)
+            return min(
+                (epsilon / norm(x[ord-1], Inf))^inv(ord - 1),
+                (epsilon / norm(x[ord], Inf))^inv(ord),
+            )
+        end
+
+        function norm_based_stepsize(q::AbstractVector, epsilon)
+            h = typemax(Float64)
+            for i in eachindex(q)
+                h = min(h, norm_based_stepsize(q[i], epsilon))
+            end
+            return h
+        end
+
+        x0T1 = Taylor1(Taylor1([1.0, 0.2], 2), 5)
+        x1T1 = Taylor1(Taylor1([-2.0, 0.1], 2), 5)
+        x0T1[4] = Taylor1([2.0, -3.0], 2)
+        x0T1[5] = Taylor1([0.5, 4.0], 2)
+        x1T1[4] = Taylor1([3.0, 0.1], 2)
+        x1T1[5] = Taylor1([-0.5, 0.2], 2)
+        qT1 = [x0T1, x1T1]
+        @test TaylorIntegration.stepsize(qT1, _abstol) ≈ norm_based_stepsize(qT1, _abstol)
+
+        vars = variables!("xi", numvars=2, order=2)
+        x0TN = Taylor1(1.0 + vars[1], 5)
+        x1TN = Taylor1(-2.0 + vars[2], 5)
+        x0TN[4] = 2.0 - 3.0 * vars[1]
+        x0TN[5] = 0.5 + 4.0 * vars[2]
+        x1TN[4] = 3.0 + 0.1 * vars[1]
+        x1TN[5] = -0.5 + 0.2 * vars[2]
+        qTN = [x0TN, x1TN]
+        @test TaylorIntegration.stepsize(qTN, _abstol) ≈ norm_based_stepsize(qTN, _abstol)
+
         sol = @test_logs(
             (Warn, zero_stepsize()),
             @inferred(

--- a/test/rootfinding.jl
+++ b/test/rootfinding.jl
@@ -221,6 +221,50 @@ import Logging: Warn
         @test norm(solN(tvN[i+1]) - xvN[i+1, :], Inf) < 1e-12
     end
 
+    root_cache = TaylorIntegration.init_cache(
+        Val(true),
+        t0,
+        x0N,
+        100,
+        _order,
+        pendulum!,
+        nothing,
+    )
+    sol_root_cache1 = (@test_logs min_level = Logging.Warn TaylorIntegration.taylorinteg!(
+        Val(true),
+        pendulum!,
+        g,
+        x0N,
+        t0,
+        Tend / 4,
+        _abstol,
+        root_cache,
+        nothing;
+        maxsteps = 100,
+        reltol = _reltol,
+    ))
+    stored_root_cache_p = root_cache.psol[1, 1]
+    sol_root_cache1_p = sol_root_cache1.p[1, 1]
+    sol_root_cache1_p_snapshot = TaylorIntegration._stored_taylor(sol_root_cache1_p)
+    sol_root_cache2 = (@test_logs min_level = Logging.Warn TaylorIntegration.taylorinteg!(
+        Val(true),
+        pendulum!,
+        g,
+        x0N .+ [0.1, 0.0],
+        t0,
+        Tend / 4,
+        _abstol,
+        root_cache,
+        nothing;
+        maxsteps = 100,
+        reltol = _reltol,
+    ))
+    @test root_cache.psol[1, 1] === stored_root_cache_p
+    @test sol_root_cache1.p[1, 1] == sol_root_cache1_p_snapshot
+    @test sol_root_cache1.p[1, 1] !== root_cache.psol[1, 1]
+    @test sol_root_cache2.p[1, 1] !== sol_root_cache1.p[1, 1]
+    @test sol_root_cache2.p[1, 1] != sol_root_cache1_p_snapshot
+
     #testing 0-th root-finding + Taylor1 jet transport
     sol1 = (@test_logs min_level = Logging.Warn taylorinteg(
         pendulum!,

--- a/test/rootfinding.jl
+++ b/test/rootfinding.jl
@@ -29,7 +29,7 @@ import Logging: Warn
     x0 = [1.3, 0.0]
     Tend = 7.019250311844546
 
-    p = variables!("ξ", numvars = length(x0), order = 2)
+    p = variables!("ξ", numvars = length(x0), order = 2, nowarn = true)
     x0N = x0 + p
     ξ = Taylor1(2)
     x01 = x0 + [ξ, ξ]

--- a/test/rootfinding.jl
+++ b/test/rootfinding.jl
@@ -245,7 +245,7 @@ import Logging: Warn
     ))
     stored_root_cache_p = root_cache.psol[1, 1]
     sol_root_cache1_p = sol_root_cache1.p[1, 1]
-    sol_root_cache1_p_snapshot = TaylorIntegration._stored_taylor(sol_root_cache1_p)
+    sol_root_cache1_p_snapshot = TaylorIntegration._stored_value(sol_root_cache1_p)
     sol_root_cache2 = (@test_logs min_level = Logging.Warn TaylorIntegration.taylorinteg!(
         Val(true),
         pendulum!,

--- a/test/solution.jl
+++ b/test/solution.jl
@@ -26,6 +26,23 @@ import Logging: Warn
     @test firsttime(sol_big) == BigFloat(0)
     @test lasttime(sol_big) == BigFloat(0)
 
+    ξ = variables!("ξ", numvars = 2, order = 2)
+    p_scalar = Vector{Taylor1{TaylorN{Float64}}}(undef, 1)
+    x_scalar = Taylor1(1.0 + ξ[1], 3)
+    TaylorIntegration.set_psol!(Val(true), p_scalar, 1, x_scalar)
+    x_scalar[0][0] = 10.0
+    @test p_scalar[1][0][0] == 1.0
+    TaylorIntegration.set_psol!(Val(true), p_scalar, 1, x_scalar)
+    @test p_scalar[1] == x_scalar
+
+    p_vector = Matrix{Taylor1{TaylorN{Float64}}}(undef, 2, 1)
+    x_vector = [Taylor1(1.0 + ξ[1], 3), Taylor1(2.0 + ξ[2], 3)]
+    TaylorIntegration.set_psol!(Val(true), p_vector, 1, x_vector)
+    x_vector[1][0][0] = 20.0
+    @test p_vector[1, 1][0][0] == 1.0
+    TaylorIntegration.set_psol!(Val(true), p_vector, 1, x_vector)
+    @test p_vector[:, 1] == x_vector
+
     xt1 = Taylor1.([1.0, 2.0], 2)
     sol_t1 = TaylorIntegration.build_solution(tv, xt1)
     @test sol_t1.x == xt1

--- a/test/solution.jl
+++ b/test/solution.jl
@@ -26,7 +26,7 @@ import Logging: Warn
     @test firsttime(sol_big) == BigFloat(0)
     @test lasttime(sol_big) == BigFloat(0)
 
-    ξ = variables!("ξ", numvars = 2, order = 2)
+    ξ = variables!("ξ", numvars = 2, order = 2, nowarn = true)
     p_scalar = Vector{Taylor1{TaylorN{Float64}}}(undef, 1)
     x_scalar = Taylor1(1.0 + ξ[1], 3)
     TaylorIntegration.set_psol!(Val(true), p_scalar, 1, x_scalar)
@@ -224,7 +224,7 @@ import Logging: Warn
     @test solfile.t isa Vector
     @test solfile.p isa Array
 
-    dq = TaylorSeries.variables!("dq", order = 2, numvars = 2)
+    dq = TaylorSeries.variables!("dq", order = 2, numvars = 2, nowarn = true)
     pN = soldense.p .* Taylor1(one(dq[1]), TaylorSeries.order(soldense))
     solN = TaylorSolution(soldense.t, pN)
     jld2_path = tempname() * ".jld2"

--- a/test/solution.jl
+++ b/test/solution.jl
@@ -37,9 +37,8 @@ import Logging: Warn
     stored_scalar = p_scalar[1]
     x_scalar_next = Taylor1(3.0 + ξ[2], 3)
     TaylorIntegration.set_psol!(Val(true), p_scalar, 1, x_scalar_next)
-    @test stored_scalar == x_scalar
     @test p_scalar[1] == x_scalar_next
-    @test p_scalar[1] !== stored_scalar
+    @test p_scalar[1] === stored_scalar
 
     p_vector = Matrix{Taylor1{TaylorN{Float64}}}(undef, 2, 1)
     x_vector = [Taylor1(1.0 + ξ[1], 3), Taylor1(2.0 + ξ[2], 3)]
@@ -51,9 +50,55 @@ import Logging: Warn
     stored_vector = p_vector[:, 1]
     x_vector_next = [Taylor1(4.0 + ξ[1], 3), Taylor1(5.0 + ξ[2], 3)]
     TaylorIntegration.set_psol!(Val(true), p_vector, 1, x_vector_next)
-    @test stored_vector == x_vector
     @test p_vector[:, 1] == x_vector_next
-    @test all(p_vector[:, 1] .!== stored_vector)
+    @test all(p_vector[:, 1] .=== stored_vector)
+
+    @taylorize function dense_cache_harmonic!(dx, x, p, t)
+        dx[1] = x[2]
+        dx[2] = -x[1]
+        return nothing
+    end
+    q_cache = [1.0 + ξ[1], 0.0 + ξ[2]]
+    cache = TaylorIntegration.init_cache(
+        Val(true),
+        0.0,
+        q_cache,
+        100,
+        12,
+        dense_cache_harmonic!,
+        nothing,
+    )
+    sol_cache1 = TaylorIntegration.taylorinteg!(
+        Val(true),
+        dense_cache_harmonic!,
+        q_cache,
+        0.0,
+        1.0,
+        1e-18,
+        cache,
+        nothing;
+        maxsteps=100,
+    )
+    stored_cache_p = cache.psol[1, 1]
+    sol_cache1_p = sol_cache1.p[1, 1]
+    sol_cache1_p_snapshot = TaylorIntegration._stored_taylor(sol_cache1_p)
+    q_cache_next = [2.0 + ξ[1], 0.0 + ξ[2]]
+    sol_cache2 = TaylorIntegration.taylorinteg!(
+        Val(true),
+        dense_cache_harmonic!,
+        q_cache_next,
+        0.0,
+        1.0,
+        1e-18,
+        cache,
+        nothing;
+        maxsteps=100,
+    )
+    @test cache.psol[1, 1] === stored_cache_p
+    @test sol_cache1.p[1, 1] == sol_cache1_p_snapshot
+    @test sol_cache1.p[1, 1] !== cache.psol[1, 1]
+    @test sol_cache2.p[1, 1] !== sol_cache1.p[1, 1]
+    @test sol_cache2.p[1, 1] != sol_cache1_p_snapshot
 
     xv_store = Matrix{TaylorN{Float64}}(undef, 2, 1)
     x_state = [1.0 + ξ[1], 2.0 + ξ[2]]

--- a/test/solution.jl
+++ b/test/solution.jl
@@ -246,4 +246,61 @@ import Logging: Warn
     @test solNfile == solN
     @test solNfile.t isa Vector
     @test solNfile.p isa Array
+
+    @taylorize function dense_cache_kepler!(dx, x, p, t)
+        r_p3d2 = (x[1]^2 + x[2]^2)^1.5
+
+        dx[1] = x[3]
+        dx[2] = x[4]
+        dx[3] = -x[1] / r_p3d2
+        dx[4] = -x[2] / r_p3d2
+
+        return nothing
+    end
+    varorder = 2
+    dq = variables!("xi", numvars = 4, order = varorder, nowarn = true)
+    q01 = [0.2, 0.0, 0.0, 3.0] .+ dq
+    q02 = [0.2, 0.0, 0.0, -3.0] .+ dq
+    kepler_cache = TaylorIntegration.init_cache(
+        Val(true),
+        0.0,
+        q01,
+        200,
+        20,
+        dense_cache_kepler!,
+        nothing,
+    )
+    sol_kepler1 = TaylorIntegration.taylorinteg!(
+        Val(true),
+        dense_cache_kepler!,
+        q01,
+        0.0,
+        1.0,
+        1e-18,
+        kepler_cache,
+        nothing;
+        maxsteps=200,
+        copy_solution=Val(true),
+    )
+    sol_kepler1_x_snapshot = map(TaylorIntegration._stored_value, sol_kepler1.x)
+    sol_kepler1_p_snapshot = map(TaylorIntegration._stored_value, sol_kepler1.p)
+    stored_kepler_cache_p = kepler_cache.psol[1, 1]
+    sol_kepler2 = TaylorIntegration.taylorinteg!(
+        Val(true),
+        dense_cache_kepler!,
+        q02,
+        0.0,
+        1.0,
+        1e-18,
+        kepler_cache,
+        nothing;
+        maxsteps=200,
+        copy_solution=Val(true),
+    )
+    @test kepler_cache.psol[1, 1] === stored_kepler_cache_p
+    @test sol_kepler1.x == sol_kepler1_x_snapshot
+    @test sol_kepler1.p == sol_kepler1_p_snapshot
+    @test sol_kepler1.p[1, 1] !== kepler_cache.psol[1, 1]
+    @test sol_kepler2.x != sol_kepler1_x_snapshot
+    @test sol_kepler2.p != sol_kepler1_p_snapshot
 end

--- a/test/solution.jl
+++ b/test/solution.jl
@@ -34,6 +34,12 @@ import Logging: Warn
     @test p_scalar[1][0][0] == 1.0
     TaylorIntegration.set_psol!(Val(true), p_scalar, 1, x_scalar)
     @test p_scalar[1] == x_scalar
+    stored_scalar = p_scalar[1]
+    x_scalar_next = Taylor1(3.0 + ξ[2], 3)
+    TaylorIntegration.set_psol!(Val(true), p_scalar, 1, x_scalar_next)
+    @test stored_scalar == x_scalar
+    @test p_scalar[1] == x_scalar_next
+    @test p_scalar[1] !== stored_scalar
 
     p_vector = Matrix{Taylor1{TaylorN{Float64}}}(undef, 2, 1)
     x_vector = [Taylor1(1.0 + ξ[1], 3), Taylor1(2.0 + ξ[2], 3)]
@@ -42,6 +48,12 @@ import Logging: Warn
     @test p_vector[1, 1][0][0] == 1.0
     TaylorIntegration.set_psol!(Val(true), p_vector, 1, x_vector)
     @test p_vector[:, 1] == x_vector
+    stored_vector = p_vector[:, 1]
+    x_vector_next = [Taylor1(4.0 + ξ[1], 3), Taylor1(5.0 + ξ[2], 3)]
+    TaylorIntegration.set_psol!(Val(true), p_vector, 1, x_vector_next)
+    @test stored_vector == x_vector
+    @test p_vector[:, 1] == x_vector_next
+    @test all(p_vector[:, 1] .!== stored_vector)
 
     xv_store = Matrix{TaylorN{Float64}}(undef, 2, 1)
     x_state = [1.0 + ξ[1], 2.0 + ξ[2]]

--- a/test/solution.jl
+++ b/test/solution.jl
@@ -43,6 +43,14 @@ import Logging: Warn
     TaylorIntegration.set_psol!(Val(true), p_vector, 1, x_vector)
     @test p_vector[:, 1] == x_vector
 
+    xv_store = Matrix{TaylorN{Float64}}(undef, 2, 1)
+    x_state = [1.0 + ξ[1], 2.0 + ξ[2]]
+    TaylorIntegration._store_state_column!(xv_store, 1, x_state)
+    x_state[1][0] = 30.0
+    @test xv_store[1, 1][0] == 1.0
+    TaylorIntegration._store_state_column!(xv_store, 1, x_state)
+    @test xv_store[:, 1] == x_state
+
     xt1 = Taylor1.([1.0, 2.0], 2)
     sol_t1 = TaylorIntegration.build_solution(tv, xt1)
     @test sol_t1.x == xt1

--- a/test/solution.jl
+++ b/test/solution.jl
@@ -81,7 +81,7 @@ import Logging: Warn
     )
     stored_cache_p = cache.psol[1, 1]
     sol_cache1_p = sol_cache1.p[1, 1]
-    sol_cache1_p_snapshot = TaylorIntegration._stored_taylor(sol_cache1_p)
+    sol_cache1_p_snapshot = TaylorIntegration._stored_value(sol_cache1_p)
     q_cache_next = [2.0 + ξ[1], 0.0 + ξ[2]]
     sol_cache2 = TaylorIntegration.taylorinteg!(
         Val(true),

--- a/test/taylorize.jl
+++ b/test/taylorize.jl
@@ -1444,24 +1444,40 @@ import Logging: Warn
             rv,
         )
 
-        # Test kepler1! with nested Taylor1s: fixed in JuliaDiff/TaylorSeries.jl#415
-        tT = t0 + Taylor1(_order)
-        qT = [0.2, 0.0, 0.0, 3.0] .+ zero(tT)
+        # Test Kepler problem with nested Taylor1s: fixed in JuliaDiff/TaylorSeries.jl#415
+        @taylorize function kepler1_no_local!(dq, q, p, t)
+            μ = p
+            r_p3d2 = (q[1]^2 + q[2]^2)^1.5
+
+            dq[1] = q[3]
+            dq[2] = q[4]
+            dq[3] = μ * q[1] / r_p3d2
+            dq[4] = μ * q[2] / r_p3d2
+
+            return nothing
+        end
+        qT = q0 .+ zero(tT)
         dqT = zero.(qT)
         parse_eqs, rv = (@test_logs min_level = Warn TI._determine_parsing!(
             true,
-            kepler1!,
+            kepler1_no_local!,
             tT,
             qT,
             dqT,
             -1.0,
         ))
         @test parse_eqs
+        qT_parsed = qT
+        qT = q0 .+ zero(tT)
+        dqT = similar(qT)
+        xaux = similar(qT)
+        TI.jetcoeffs!(kepler1_no_local!, tT, qT, dqT, xaux, -1.0)
+        @test qT_parsed == qT
 
         dqT_check = zero.(qT)
         @test_logs min_level = Warn TI.__jetcoeffs!(
             Val(parse_eqs),
-            kepler1!,
+            kepler1_no_local!,
             tT,
             qT,
             dqT_check,

--- a/test/taylorize.jl
+++ b/test/taylorize.jl
@@ -1443,6 +1443,32 @@ import Logging: Warn
             nothing,
             rv,
         )
+
+        # Test kepler1! with nested Taylor1s: fixed in JuliaDiff/TaylorSeries.jl#415
+        tT = t0 + Taylor1(_order)
+        qT = [0.2, 0.0, 0.0, 3.0] .+ zero(tT)
+        dqT = zero.(qT)
+        parse_eqs, rv = (@test_logs min_level = Warn TI._determine_parsing!(
+            true,
+            kepler1!,
+            tT,
+            qT,
+            dqT,
+            -1.0,
+        ))
+        @test parse_eqs
+
+        dqT_check = zero.(qT)
+        @test_logs min_level = Warn TI.__jetcoeffs!(
+            Val(parse_eqs),
+            kepler1!,
+            tT,
+            qT,
+            dqT_check,
+            zero.(qT),
+            -1.0,
+            rv,
+        )
     end
 
 

--- a/test/taylorize.jl
+++ b/test/taylorize.jl
@@ -2090,38 +2090,6 @@ import Logging: Warn
             rv,
         )
 
-        @taylorize function kepler1!(dq, q, p, t)
-            μ = p
-            r_p3d2 = (q[1]^2 + q[2]^2)^1.5
-
-            dq[1] = q[3]
-            dq[2] = q[4]
-            dq[3] = μ * q[1] / r_p3d2
-            dq[4] = μ * q[2] / r_p3d2
-
-            return nothing
-        end
-        tT = t0 + Taylor1(_order)
-        qT = [0.2, 0.0, 0.0, 3.0] .+ zero(tT)
-        parse_eqs, rv =
-            (@test_logs (Warn, unable_to_parse(kepler1!)) TI._determine_parsing!(
-                true,
-                kepler1!,
-                tT,
-                qT,
-                similar(qT),
-                -1.0,
-            ))
-        @test !parse_eqs
-        @test_throws MethodError TI.__jetcoeffs!(
-            Val(kepler1!),
-            tT,
-            qT,
-            similar(qT),
-            -1.0,
-            rv,
-        )
-
         # Error: `@taylorize` allows only to parse up tp 5-index arrays
         ex = :(function err_arr_indx!(Dz, z, p, t)
             n = size(z, 1)

--- a/test/taylorize.jl
+++ b/test/taylorize.jl
@@ -1787,7 +1787,7 @@ import Logging: Warn
         end
 
         q0 = [19.0, 20.0, 50.0] #the initial condition
-        xi = variables!("δ", order = 1, numvars = length(q0))
+        xi = variables!("δ", order = 1, numvars = length(q0), nowarn = true)
 
         sol1 = lyap_taylorinteg(
             lorenz1!,
@@ -2159,7 +2159,7 @@ import Logging: Warn
         end
 
         varorder = 4 #the order of the variational expansion
-        p = variables!("ξ", numvars = 2, order = varorder) #TaylorN steup
+        p = variables!("ξ", numvars = 2, order = varorder, nowarn = true) #TaylorN steup
         q0 = [10.0, 0.0] #the initial conditions
         q0TN = q0 + p #parametrization of a small neighbourhood around the initial conditions
 
@@ -2232,7 +2232,7 @@ import Logging: Warn
         end
 
         varorder = 2 #the order of the variational expansion
-        p = variables!("ξ", numvars = 2, order = varorder) #TaylorN steup
+        p = variables!("ξ", numvars = 2, order = varorder, nowarn = true) #TaylorN steup
         q0 = [1.3, 0.0] #the initial conditions
         q0TN = q0 + p #parametrization of a small neighbourhood around the initial conditions
         # T is the librational period == 4Elliptic.K(sin(q0[1]/2)^2)
@@ -2362,7 +2362,7 @@ import Logging: Warn
         end
 
         varorder = 2 #the order of the variational expansion
-        p = variables!("ξ", numvars = 4, order = varorder) #TaylorN setup
+        p = variables!("ξ", numvars = 4, order = varorder, nowarn = true) #TaylorN setup
         q0 = [0.2, 0.0, 0.0, 3.0]
         q0TN = q0 + p # JT initial condition
 

--- a/test/taylorize.jl
+++ b/test/taylorize.jl
@@ -1384,6 +1384,36 @@ import Logging: Warn
             rv,
         )
 
+        @taylorize function kepler_no_local!(dq, q, p, t)
+            μ = p
+            r_p3d2 = (q[1]^2 + q[2]^2)^1.5
+
+            dq[1] = q[3]
+            dq[2] = q[4]
+            dq[3] = μ * q[1] / r_p3d2
+            dq[4] = μ * q[2] / r_p3d2
+
+            return nothing
+        end
+        qT = q0 .+ zero(tT)
+        dqT = similar(qT)
+        parse_eqs, rv = (@test_logs min_level = Logging.Warn TI._determine_parsing!(
+            true,
+            kepler_no_local!,
+            tT,
+            qT,
+            dqT,
+            -1.0,
+        ))
+        @test parse_eqs
+        qT_parsed = qT
+
+        qT = q0 .+ zero(tT)
+        dqT = similar(qT)
+        xaux = similar(qT)
+        TI.jetcoeffs!(kepler_no_local!, tT, qT, dqT, xaux, -1.0)
+        @test qT_parsed == qT
+
         qT = q0 .+ zero(tT)
         dqT = similar(qT)
         rv = (@test_logs min_level = Logging.Warn TI._allocate_jetcoeffs!(


### PR DESCRIPTION
This PR aims at improving overall performance of the package from mostly two different angles:

- On JT integrations, `stepsize` noticeably allocates. Here, we fix this by "taylorizing" by hand this method.
- Avoid `deepcopy` and instead rely on`TaylorSeries.identity!`: this avoids extra work by `deepcopy` not needed here, while maintaning full independency of objects in memory where needed (i.e., avoiding aliasing) and minimally allocating as much as possible.
- Other scattered fixes.