### PR TITLE
Import SciMLBase-owned names from SciMLBase in the DiffEq extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "TaylorIntegration"
 uuid = "92b13dbe-c966-51a2-8445-caca9f8a7d42"
-version = "0.18.15"
+version = "0.18.16"
 repo = "https://github.com/PerezHz/TaylorIntegration.jl.git"
 
 [deps]
@@ -20,9 +20,10 @@ TaylorSeries = "6aa5eb33-94cf-58f4-a9d0-e4b2c4fc25ea"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 IntervalArithmetic = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"
 OrdinaryDiffEqCore = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
+SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 
 [extensions]
-TaylorIntegrationDiffEqExt = ["DiffEqBase", "OrdinaryDiffEqCore"]
+TaylorIntegrationDiffEqExt = ["DiffEqBase", "OrdinaryDiffEqCore", "SciMLBase"]
 TaylorIntegrationIAExt = "IntervalArithmetic"
 
 [compat]
@@ -44,6 +45,7 @@ Pkg = "<0.0.1, 1"
 PkgBenchmark = "0.2"
 RecursiveArrayTools = "2, 3, 4"
 Reexport = "1"
+SciMLBase = "2, 3"
 StaticArrays = "0.12.5, 1"
 TaylorSeries = "0.22.1"
 Test = "<0.0.1, 1"
@@ -60,9 +62,10 @@ OrdinaryDiffEqCore = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 PkgBenchmark = "32113eaa-f34f-5b0d-bd6c-c81e245fc73d"
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
+SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 TaylorSeries = "6aa5eb33-94cf-58f4-a9d0-e4b2c4fc25ea"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "Elliptic", "InteractiveUtils", "IntervalArithmetic", "LinearAlgebra", "Logging", "OrdinaryDiffEqCore", "Pkg", "RecursiveArrayTools", "StaticArrays", "TaylorSeries", "Test"]
+test = ["Aqua", "Elliptic", "InteractiveUtils", "IntervalArithmetic", "LinearAlgebra", "Logging", "OrdinaryDiffEqCore", "Pkg", "RecursiveArrayTools", "SciMLBase", "StaticArrays", "TaylorSeries", "Test"]

--- a/ext/TaylorIntegrationDiffEqExt.jl
+++ b/ext/TaylorIntegrationDiffEqExt.jl
@@ -6,11 +6,11 @@ using TaylorIntegration
 
 using DiffEqBase: DynamicalODEFunction
 import DiffEqBase
-using OrdinaryDiffEqCore:
+using SciMLBase:
     ODEFunction,
     ODEProblem,
-    DynamicalODEProblem,
-    @cache
+    DynamicalODEProblem
+using OrdinaryDiffEqCore: @cache
 import OrdinaryDiffEqCore
 
 using StaticArrays: SVector, SizedArray

--- a/test/common.jl
+++ b/test/common.jl
@@ -1,5 +1,13 @@
 using TaylorIntegration, Test
 using OrdinaryDiffEqCore
+using SciMLBase:
+    ODEProblem,
+    DynamicalODEProblem,
+    DiscreteCallback,
+    ContinuousCallback,
+    VectorContinuousCallback,
+    isinplace,
+    solve
 using LinearAlgebra: norm
 using StaticArrays
 using Logging

--- a/test/taylorize.jl
+++ b/test/taylorize.jl
@@ -1,6 +1,7 @@
 # This file is part of the TaylorIntegration.jl package; MIT licensed
 
 using TaylorIntegration, OrdinaryDiffEqCore
+using SciMLBase: ODEProblem, solve
 using Test
 using LinearAlgebra: norm
 using InteractiveUtils: methodswith


### PR DESCRIPTION
Advance notice of an upstream change plus a tested fix. Nothing is broken in the registry today, and no action is urgent — see "No time pressure" at the bottom.

## What will break

`OrdinaryDiffEqCore` on SciML master (`version = "4.14.0"`, not yet registered) removed its blanket `@reexport using SciMLBase` in [SciML/OrdinaryDiffEq.jl#4119](https://github.com/SciML/OrdinaryDiffEq.jl/pull/4119) (`4ca8a4c2c`). That dropped 152 of its exports (374 → 227), including `ODEFunction` and `DynamicalODEProblem`. It is a minor bump, and `TaylorIntegration`'s weak compat (`OrdinaryDiffEqCore = "3.17, 4"`) admits it, so `TaylorIntegrationDiffEqExt` would start resolving against it as soon as 4.14.0 is registered.

With `TaylorIntegration` v0.18.15 unchanged and `OrdinaryDiffEqCore` at master, the extension fails to precompile on Julia 1.12:

```
WARNING: Imported binding OrdinaryDiffEqCore.ODEFunction was undeclared at import time during import to TaylorIntegrationDiffEqExt.
WARNING: Imported binding OrdinaryDiffEqCore.DynamicalODEProblem was undeclared at import time during import to TaylorIntegrationDiffEqExt.
ERROR: LoadError: UndefVarError: `ODEFunction` not defined in `TaylorIntegrationDiffEqExt`
Suggestion: this global was defined as `OrdinaryDiffEqCore.ODEFunction` but not assigned a value.
Hint: a global variable of this name also exists in SciMLBase.
Stacktrace:
 [1] top-level scope
   @ ~/TaylorIntegration.jl/ext/TaylorIntegrationDiffEqExt.jl:396
in expression starting at ~/TaylorIntegration.jl/ext/TaylorIntegrationDiffEqExt.jl:3
```

`Pkg.test` on unmodified v0.18.15 against that `OrdinaryDiffEqCore` does not reach a single testset — it stops at `The following 1 direct dependency failed to precompile: TaylorIntegration → TaylorIntegrationDiffEqExt`.

Cause: `ODEFunction`, `ODEProblem` and `DynamicalODEProblem` are owned and exported by `SciMLBase`; `OrdinaryDiffEqCore` was only forwarding them.

The same removal also un-exports names that `test/common.jl` and `test/taylorize.jl` pick up from `using OrdinaryDiffEqCore`. Checked by resolving every `SciMLBase`-owned symbol those two files reference against master's exports:

- `test/common.jl`: `ODEProblem`, `DynamicalODEProblem`, `DiscreteCallback`, `ContinuousCallback`, `VectorContinuousCallback`, `isinplace`, `solve`
- `test/taylorize.jl`: `ODEProblem`, `solve`

## What this PR changes

Import those names from `SciMLBase` directly instead of via `OrdinaryDiffEqCore`'s re-export. This is the same migration SciML applied to its own sublibraries ([#4167](https://github.com/SciML/OrdinaryDiffEq.jl/pull/4167), [#4174](https://github.com/SciML/OrdinaryDiffEq.jl/pull/4174)).

`SciMLBase` was not reachable from inside the extension, so it is added to `[weakdeps]` and to the `TaylorIntegrationDiffEqExt` trigger list. That does not narrow when the extension loads: `DiffEqBase` depends on `SciMLBase`, so any session that satisfies the existing trigger already has `SciMLBase` loaded. Confirmed below by loading only `TaylorIntegration`, `OrdinaryDiffEqCore` and `DiffEqBase` and checking `Base.get_extension` returns a live module. `SciMLBase` is also added to `[extras]`/`[targets]` for the two test files, and a `[compat]` entry is added.

Version bumped `0.18.15 → 0.18.16` to match the convention in recent PRs here; happy to drop that if you'd rather do the bump separately.

## Verification

Julia 1.12.6, Linux. Four configurations.

**1. Unmodified v0.18.15 + `OrdinaryDiffEqCore` 4.13.0 (current registered)** — baseline, passes:

```
Testing `common.jl` |  198    198  6m27.2s
Testing `taylorize.jl` |  431    431  2m47.3s
Aqua tests (additional) |   11     11  30.5s
     Testing TaylorIntegration tests passed
```

**2. Unmodified v0.18.15 + `OrdinaryDiffEqCore` master 4.14.0** — fails, extension does not precompile (error pasted above); no testsets run.

**3. This branch + `OrdinaryDiffEqCore` 4.13.0 (current registered)** — passes, same counts as the baseline:

```
$ julia +1.12 --project -e 'using Pkg; Pkg.test("TaylorIntegration")'
Testing `solution.jl` |   80     80  41.7s
Testing `one_ode.jl` |  101    101  3.3s
Testing `many_ode.jl` |  117    117  9.9s
Testing `complex.jl` |   74     74  5.1s
Testing `jettransport.jl` |  376    376  30.1s
Testing `lyapunov.jl` |  177    177  18.1s
Testing `bigfloats.jl` |   16     16  13.0s
Testing `common.jl` |  198    198  5m28.6s
Testing `rootfinding.jl` |  331    331  18.9s
Testing `taylorize.jl` |  431    431  2m26.1s
Testing integrations with intervals |   24     24  10.4s
Aqua tests (performance) |    1      1  1.0s
Aqua tests (additional) |   11     11  33.7s
     Testing TaylorIntegration tests passed
```

**4. This branch + `OrdinaryDiffEqCore` master 4.14.0 (dev'd from `SciML/OrdinaryDiffEq.jl@b45ffed`)** — passes, same counts:

```
Testing `solution.jl` |   80     80  43.1s
Testing `one_ode.jl` |  101    101  3.5s
Testing `many_ode.jl` |  117    117  9.4s
Testing `complex.jl` |   74     74  5.3s
Testing `jettransport.jl` |  376    376  29.1s
Testing `lyapunov.jl` |  177    177  18.1s
Testing `bigfloats.jl` |   16     16  12.6s
Testing `common.jl` |  198    198  5m30.9s
Testing `rootfinding.jl` |  331    331  19.5s
Testing `taylorize.jl` |  431    431  2m37.7s
Testing integrations with intervals |   24     24  12.0s
Aqua tests (performance) |    1      1  1.5s
Aqua tests (additional) |   11     11  33.3s
     Testing TaylorIntegration tests passed
```

Extension really is active on master (loading only the existing trigger packages, no explicit `using SciMLBase`):

```julia
julia> using TaylorIntegration, OrdinaryDiffEqCore, DiffEqBase
julia> Base.get_extension(TaylorIntegration, :TaylorIntegrationDiffEqExt)
TaylorIntegrationDiffEqExt
julia> pkgversion(OrdinaryDiffEqCore)
v"4.14.0"
```

Bottom of the new `SciMLBase = "2, 3"` compat range also checked (`OrdinaryDiffEqCore` 3.17.1, `SciMLBase` 2.153.1):

```
ext = TaylorIntegrationDiffEqExt
Core = 3.17.1
SciMLBase = 2.153.1
sol[end] = 2.718281828459045  alg = TaylorIntegrationDiffEqExt.TaylorMethodParams
```

Not verified: Windows and macOS runners, Julia 1.10 (the failure mode is a hard error only on 1.12's stricter binding-at-import rules; on 1.10 the same imports produce warnings), and the docs build.

## No time pressure

Registered v0.18.4–0.18.15 are being protected independently by a retroactive weak-compat cap in the registry, capping `OrdinaryDiffEqCore` at `<= 4.13` for those versions: [JuliaRegistries/General#163937](https://github.com/JuliaRegistries/General/pull/163937). So existing users will not break whether or not this PR is merged; this is only about making a future release work with `OrdinaryDiffEqCore` 4.14.0 and later.

Background and the full cross-package analysis: [SciML/OrdinaryDiffEq.jl#4175](https://github.com/SciML/OrdinaryDiffEq.jl/issues/4175).
